### PR TITLE
feat: add project scaffold docs, specs, examples, and scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ Thumbs.db
 .env
 .env.local
 
+# Research (private, not for open-source distribution)
+docs/research/*.md
+
 # Build
 *.d
 *.o

--- a/deployments/docker-compose/README.md
+++ b/deployments/docker-compose/README.md
@@ -1,0 +1,166 @@
+# Docker Compose Deployments
+
+This directory contains production-ready Docker Compose configurations for various deployment scenarios.
+
+## Single-Node (Development)
+
+See [../examples/single-node/](../examples/single-node/) for a complete development setup.
+
+## Production Multi-Node
+
+For production deployments with multiple gateway instances, use:
+
+```yaml
+version: '3.9'
+
+services:
+  redis-primary:
+    image: redis:7-alpine
+    container_name: redis-primary
+    ports:
+      - "6379:6379"
+    command: redis-server --requirepass changeme
+    volumes:
+      - redis_primary_data:/data
+    networks:
+      - api-gateway
+
+  redis-replica:
+    image: redis:7-alpine
+    container_name: redis-replica
+    ports:
+      - "6380:6379"
+    command: redis-server --slaveof redis-primary 6379 --requirepass changeme --masterauth changeme
+    depends_on:
+      - redis-primary
+    volumes:
+      - redis_replica_data:/data
+    networks:
+      - api-gateway
+
+  gateway-1:
+    image: api-gateway:latest
+    container_name: gateway-1
+    ports:
+      - "8080:8080"
+      - "9090:9090"
+    environment:
+      REDIS_URL: "redis://:changeme@redis-primary:6379/0"
+      LISTEN_ADDR: "0.0.0.0:8080"
+      ADMIN_ADDR: "0.0.0.0:9090"
+    volumes:
+      - ./configs/gateway.yaml:/app/configs/gateway.yaml
+    depends_on:
+      - redis-primary
+    networks:
+      - api-gateway
+
+  gateway-2:
+    image: api-gateway:latest
+    container_name: gateway-2
+    ports:
+      - "8081:8080"
+      - "9091:9090"
+    environment:
+      REDIS_URL: "redis://:changeme@redis-primary:6379/0"
+      LISTEN_ADDR: "0.0.0.0:8080"
+      ADMIN_ADDR: "0.0.0.0:9090"
+    volumes:
+      - ./configs/gateway.yaml:/app/configs/gateway.yaml
+    depends_on:
+      - redis-primary
+    networks:
+      - api-gateway
+
+  envoy-lb:
+    image: envoyproxy/envoy:v1.31-latest
+    container_name: envoy-lb
+    ports:
+      - "80:10000"
+      - "443:10001"
+    volumes:
+      - ./configs/envoy-lb.yaml:/etc/envoy/envoy.yaml
+    command: /usr/local/bin/envoy -c /etc/envoy/envoy.yaml
+    networks:
+      - api-gateway
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "9092:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+    networks:
+      - api-gateway
+
+volumes:
+  redis_primary_data:
+  redis_replica_data:
+  prometheus_data:
+
+networks:
+  api-gateway:
+    driver: bridge
+```
+
+## Key Features
+
+- **Redis Primary/Replica** for high availability
+- **Multiple Gateway Instances** for horizontal scaling
+- **Envoy Load Balancer** for external traffic distribution
+- **Prometheus** for monitoring
+- **Shared Config Volume** for atomic, coordinated updates
+
+## Environment Variables
+
+| Variable | Default | Description |
+| :---- | :---- | :---- |
+| `REDIS_URL` | `redis://redis:6379/0` | Redis connection string |
+| `LISTEN_ADDR` | `0.0.0.0:8080` | Gateway listen address |
+| `ADMIN_ADDR` | `0.0.0.0:9090` | Admin API listen address |
+| `GATEWAY_CONFIG_PATH` | `/app/configs/gateway.yaml` | Path to config file |
+| `LOG_LEVEL` | `info` | Log level (debug, info, warn, error) |
+
+## Operational Tasks
+
+### Reload Config Across All Instances
+
+```bash
+# Validate the new config
+curl -X POST http://localhost:9090/config/reload
+curl -X POST http://localhost:9091/config/reload
+
+# Check status
+curl http://localhost:9090/config/status
+curl http://localhost:9091/config/status
+```
+
+### Scale Gateway Instances
+
+```bash
+docker-compose up -d --scale gateway=5
+```
+
+(Ensure unique admin ports in docker-compose.yml)
+
+### Monitor Metrics
+
+```bash
+# View Prometheus targets
+open http://localhost:9092/targets
+
+# Query gateway metrics
+curl -s 'http://localhost:9092/api/v1/query?query=gateway_http_requests_total'
+```
+
+## Further Reading
+
+- [../../specs/config-schema.md](../../specs/config-schema.md) — Configuration
+- [../../examples/single-node/](../../examples/single-node/) — Development setup
+- [../redis/](../redis/) — Redis configuration and persistence
+- [../prometheus/](../prometheus/) — Prometheus monitoring

--- a/deployments/prometheus/prometheus.yml
+++ b/deployments/prometheus/prometheus.yml
@@ -1,0 +1,23 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'gateway'
+    static_configs:
+      - targets: ['localhost:9090']
+    metrics_path: '/metrics'
+    scrape_interval: 10s
+    scrape_timeout: 5s
+
+  - job_name: 'redis'
+    static_configs:
+      - targets: ['localhost:6379']
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: []
+
+rule_files:
+  - "alert_rules.yml"

--- a/docs/architecture/API_GATEWAY_DESIGN.md
+++ b/docs/architecture/API_GATEWAY_DESIGN.md
@@ -1,0 +1,128 @@
+# Advanced API Gateway Architecture: From Local Clusters to Hyperscale
+
+## 1. HIGH-LEVEL ARCHITECTURE
+
+The API Gateway serves as the critical ingress boundary and unified interface for all internal and external clients interacting with a distributed microservices ecosystem. Designing a production-grade system that operates securely within a constrained, potentially unreliable local area network (LAN) containing 10 to 50 nodes, while remaining conceptually scalable to hyperscale deployments processing millions of requests per second, demands a strict decoupling of responsibilities. The fundamental architectural paradigm rests on the absolute separation of the Data Plane and the Control Plane.
+
+The Data Plane constitutes the fleet of highly optimized proxy instances responsible for the critical path of the request. These nodes terminate Transport Layer Security (TLS), decode Layer 7 payloads, enforce access control, execute rate limiting, and route bytes to upstream endpoints. The Data Plane must be stateless, horizontally scalable, and capable of autonomous operation during network partitions. Conversely, the Control Plane provides centralized management. It is responsible for ingesting declarative configurations, watching service registries for topology changes, and asynchronously pushing deterministic routing tables and cryptographic material to the Data Plane fleet without blocking live traffic.
+
+```
++-------------------------------------------------------------------+
+| CONTROL PLANE                                                     |
+|                                                                   |
+| +-------------+ +------------------+ +----------------+         |
+| | Config API  | | xDS gRPC Server  | | Service Mesh   |         |
+| | (CRUD)      |---> | (Delta Push)     |<---- | Discovery  |         |
+| +-------------+ +------------------+ +----------------+         |
+|   |               |                     |                         |
+|   v               v                     v                         |
+| +-------------+ +------------------+ +----------------+         |
+| | PostgreSQL  | | TLS/Cert Manager | | etcd / Consul  |         |
+| | (Policies)  | | (JWKS Fetcher)   | | (Topology)     |         |
+| +-------------+ +------------------+ +----------------+         |
++-------------------------------------------------------------------+
+           |
+           | xDS Streams
+           v
++-------------------------------------------------------------------+
+| DATA PLANE                                                        |
+|                                                                   |
+| +-----------------------------------------------+                |
+| | Atomic Configuration Swaps                    |                |
+| +-----------------------------------------------+                |
+| External       | TLS Termination & HTTP/2 / QUIC |   Internal   |
+| Clients ------->|-------------------------------------|> Microservices|
+|                | AuthZ -> Rate Limit -> L7 Routing |            |
+|                +----------------------------------|   |
+|                      |                           |            |
+|                      v                           |            |
+|                +-----------------------------+   |            |
+|                | Async Telemetry & Logging  |   |            |
+|                +-----------------------------+   |            |
++-------------------------------------------------------------------+
+```
+
+The request lifecycle traverses a strict, deterministic pipeline designed to fail fast and shed load at the earliest possible stage. When a client initiates an API call, the Data Plane first accepts the TCP connection and negotiates the TLS handshake. The raw byte stream is parsed into an internal HTTP representation, and headers are normalized to prevent request smuggling attacks. The gateway then extracts authentication credentials, typically JSON Web Tokens (JWT) or mutual TLS (mTLS) client certificates, and validates the cryptographic signature locally.
+
+Once authenticated, the principal's identity is evaluated against rate-limiting quotas to prevent resource exhaustion. If capacity allows, the gateway evaluates the requested URI and HTTP method against an authorization matrix. The routing engine then matches the path against an in-memory radix tree to select an upstream cluster. A load-balancing algorithm, such as exponentially weighted moving average or least connections, selects a specific healthy endpoint from that cluster. Finally, the gateway injects contextual tracing headers, establishes an upstream connection, streams the payload, and subsequently streams the response back to the client while asynchronously emitting telemetry data.
+
+In a local-first deployment, the Control Plane and Data Plane may run as separate processes on the same set of physical machines, utilizing file-based configuration or local sockets to minimize dependencies. At an internet-scale deployment, the Control Plane is completely isolated onto dedicated, highly available compute clusters, distributing state to thousands of ephemeral Data Plane nodes distributed across multiple geographic regions via advanced streaming protocols.
+
+## 2. ROUTING DESIGN
+
+Routing dictates how external URIs map to internal microservices, requiring both static pattern matching and dynamic endpoint resolution. At the API Gateway layer, routing is predominantly executed at Layer 7 (Application), allowing decisions to be based on HTTP headers, cookies, and payload content. This contrasts with Layer 4 (Transport) load balancing, which operates purely on IP addresses and ports. While Layer 4 is exceptionally fast, it lacks the context necessary to perform intelligent application routing, such as sticky sessions or request coalescing.
+
+Service discovery is the mechanism by which the gateway maintains an accurate, real-time registry of upstream endpoints. The choice of service discovery tool fundamentally alters the system's resilience to network instability, presenting a critical divergence between local and hyperscale deployments.
+
+| Discovery Tool | Consensus Mechanism | Consistency Model | Primary Use Case | Trade-offs |
+| :---- | :---- | :---- | :---- | :---- |
+| **etcd** | Raft | Strong (Linearizable) | Hyperscale, Kubernetes | Stalls during network partitions; minority nodes reject writes. |
+| **Consul** | Gossip + Raft | Eventual (Adjustable) | Unreliable LAN, Multi-DC | Complex architecture; temporary routing to dead nodes during convergence. |
+| **mDNS** | Multicast | None | Zero-config local development | Broadcast storms; cannot scale beyond a single subnet. |
+
+For the local cluster variant operating on an office LAN with 10 to 50 machines, the network is assumed to be unreliable. In this environment, relying on a strongly consistent store like etcd is an architectural vulnerability. If a network switch fails and partitions the cluster, etcd will fail to achieve a quorum in the minority partition, entirely paralyzing service registration and discovery. Therefore, the local variant implements service discovery via Consul using a Gossip protocol. Gossip protocols disseminate state epidemically, meaning that even if the network fragments, nodes within the same isolated partition can still exchange health status and route local traffic, favoring availability over strict consistency.
+
+Conversely, the scalable distributed version operating at hyperscale cannot rely on gossip protocols, as the bandwidth and CPU overhead of epidemic state sharing among tens of thousands of nodes becomes catastrophic. Hyperscale environments necessitate centralized, highly available Control Planes backed by strongly consistent key-value stores like etcd, which serves as the backbone for systems like Kubernetes. To protect the etcd cluster from the thundering herd of thousands of Data Plane nodes requesting routing updates, the API Gateway never queries etcd directly. Instead, the Control Plane acts as a translation layer, watching etcd for changes via long-polling, flattening the topology into an Endpoint Discovery Service (EDS) payload, and streaming it to the Data Plane proxies.
+
+## 3. AUTHENTICATION / AUTHORIZATION
+
+Security at the edge must be computationally efficient, completely stateless, and resilient to backend database outages. The API Gateway must act as the primary enforcement point, shielding internal microservices from unauthenticated traffic.
+
+The evaluation of authentication mechanisms reveals significant scaling disparities between traditional session management, JSON Web Tokens (JWT), and mutual TLS (mTLS). Session-based authentication requires the server to maintain state, either in memory or via a centralized database like Redis. While this permits immediate session revocation, it introduces high latency via synchronous database lookups on every request, rendering it unviable for millions of requests per second.
+
+To satisfy the constraints of hyperscale, the gateway relies on a defense-in-depth approach utilizing JWTs at Layer 7 and mTLS at Layer 4. External clients authenticate via JWTs embedded in the HTTP Authorization header. Because JWTs encapsulate the user's identity and authorization claims cryptographically, the Data Plane can validate the token purely via CPU computation, completely eliminating network I/O. Once the gateway validates the JWT, it initiates an mTLS connection to the internal upstream service. This guarantees that internal services only accept traffic originating from the authenticated gateway, preventing lateral movement if an attacker breaches the perimeter.
+
+Validating JWTs symmetrically using a shared secret is a severe anti-pattern that leads to catastrophic key sprawl; if the shared secret is leaked, an attacker can forge administrative tokens. The Gateway strictly enforces asymmetric cryptography (e.g., RS256 or ECDSA). The validation logic executes entirely within the Data Plane proxy. To achieve this without coupling the proxy to the Identity Provider (IdP), the Gateway fetches public keys from the IdP's JSON Web Key Set (JWKS) URI.
+
+The key rotation strategy is critical to ensure that active user sessions are not dropped during cryptographic updates. The implementation relies on a graceful rotation window. The Identity Provider generates a new key pair and publishes the new public key to the JWKS endpoint alongside the old public key, assigning a unique Key ID (kid) to each. The gateway caches this JWKS response. When a request arrives, the gateway extracts the kid from the unverified JWT header and selects the corresponding public key from its cache to verify the signature. The old key remains in the JWKS until all tokens signed by it have organically expired, at which point it is safely removed.
+
+In a local cluster, the gateway can afford to fetch the JWKS directly from the IdP upon encountering an unknown kid. At internet scale, fetching JWKS directly from the IdP risks a denial-of-service attack against the authentication server if thousands of gateways encounter cache misses simultaneously. Furthermore, JWTs inherently lack immediate revocation capabilities. To solve this at scale, the Control Plane maintains a centralized revocation list and generates a Bloom filter representing all revoked token IDs (jti). This highly compressed Bloom filter is pushed to all Data Plane nodes via an asynchronous pub/sub channel. When validating a JWT, the Data Plane first checks the local Bloom filter; if the filter returns negative, the token is mathematically guaranteed to be valid, and the request proceeds immediately. Only if the filter returns a positive match does the gateway incur the latency penalty of querying a distributed cache to confirm the revocation, effectively reconciling the statelessness of JWTs with the security of instantaneous invalidation.
+
+## 4. RATE LIMITING
+
+Rate limiting is an essential pattern for regulating network traffic, serving as a critical control mechanism against distributed denial-of-service (DDoS) attacks and unintentional backend overload. Designing a rate limiter necessitates navigating the CAP theorem, explicitly trading strict consistency for high availability and low latency in a partitioned environment.
+
+The selection of the underlying rate-limiting algorithm heavily influences the memory profile and burst tolerance of the system:
+
+| Algorithm | Mechanism | Memory Cost | Accuracy | Burst Behavior |
+| :---- | :---- | :---- | :---- | :---- |
+| **Fixed Window** | Counter resets at a fixed interval boundary. | Lowest (1 key/user) | Approximate | Vulnerable to 2x burst limits at window edges. |
+| **Sliding Window Log** | Records precise timestamps in a sorted set. | Highest (O(n)) | Exact | Prevents boundary bursts entirely. |
+| **Sliding Window Counter** | Averages the current and previous window buckets. | Moderate (2 keys) | Near-exact | Smooths boundary transitions efficiently. |
+| **Token Bucket** | Tokens refill at a steady rate; requests deduct tokens. | Low (2 fields/user) | Exact | Permits controlled bursts up to bucket capacity. |
+| **Leaky Bucket** | Requests are queued and processed at a constant rate. | Low (1 key/user) | Exact | Strictly shapes traffic; zero burst tolerance. |
+
+For mixed workloads across a production API Gateway, the Token Bucket algorithm provides the optimal balance. It accommodates the bursty nature of real-world REST and WebSocket traffic while strictly enforcing a long-term average rate. It is highly memory efficient, requiring the storage of only two values per client identifier (e.g., IP address or API key): current_tokens and last_refill_timestamp.
+
+In the local cluster variant, the rate-limiting infrastructure utilizes a single highly available Redis instance. The primary failure mode in distributed rate limiting is the Time-Of-Check to Time-Of-Use (TOCTOU) race condition, where concurrent requests from the same client read the token state simultaneously, calculate that capacity remains, and overwrite the state, thereby bypassing the limit. To eliminate this without distributed locks, the Token Bucket logic is encapsulated entirely within a Server-Side Lua script. Because the Redis event loop is single-threaded, the Lua script guarantees that reading the current capacity, calculating the time-based token refill, decrementing the requested tokens, and writing the new state all execute as a single, atomic operation.
+
+At internet scale (millions of requests per second), relying on a centralized Redis cluster for synchronous Lua execution on every single API request introduces an intolerable latency penalty and a massive single point of failure. The scalable distributed version pivots to a Hierarchical Two-Tier Quota Architecture.
+
+1. **Local Quota Servers (L1):** Each Data Plane gateway maintains a fast, in-memory token bucket algorithm locally.
+2. **Global Quota Servers (L2):** A deeply sharded Redis cluster acts as the eventual source of truth.
+3. **Synchronization:** Rather than querying Redis per request, the gateway's L1 cache asynchronously pre-fetches a batch of tokens (e.g., requesting 1,000 tokens) from the L2 global server.
+4. **Local Enforcement:** The gateway enforces the limit entirely in memory with sub-millisecond latency. Once the local batch is exhausted, it asynchronously requests another allocation from the global pool while reporting its consumption.
+
+This hierarchical design deliberately embraces eventual consistency. There exists a small synchronization window where a user might marginally exceed their global quota, but this trade-off is absolutely necessary to protect the critical path latency and ensure the Redis infrastructure survives the load.
+
+## 5. OBSERVABILITY
+
+A system routing thousands or millions of requests is an opaque black box without comprehensive telemetry. The observability architecture must provide granular insights for debugging without suffocating the Data Plane's CPU or saturating the network.
+
+### Logging
+
+Writing access logs directly to disk or standard output on the critical path creates severe I/O blocking. The gateway implements asynchronous logging, where connection details, HTTP status codes, and latency profiles are written to a lock-free memory ring buffer. A dedicated background thread flushes this buffer in batches to a centralized log aggregator (e.g., Promtail or Elasticsearch), ensuring zero allocation overhead during active request processing.
+
+### Metrics
+
+The Data Plane exposes metrics via a /metrics endpoint to be scraped periodically by a Prometheus-compatible system. To prevent cardinality explosions—where dynamic URL parameters (e.g., /user/123/profile, /user/456/profile) create infinite unique metric timeseries that crash the Prometheus server—the gateway enforces strict URI normalization. Requests are mapped to parameterized route templates (e.g., /user/{id}/profile) before being attached as metric labels, ensuring high-level traffic patterns are observable without degrading the monitoring infrastructure.
+
+### Distributed Tracing and Sampling at Scale
+
+Distributed tracing, powered by OpenTelemetry (OTel), is critical for tracking request latency across microservice boundaries. The gateway injects a unique trace_id into the traceparent header of every incoming request. However, generating, exporting, and storing trace payloads for millions of requests per second is financially and computationally prohibitive.
+
+The standard mitigation is Head-Based Sampling, where the gateway randomly selects a small percentage of requests (e.g., 1%) to trace at the very beginning of the request lifecycle. While computationally cheap, this is fundamentally flawed for debugging; anomalous events, such as a backend timing out or returning an HTTP 500 error, are statistically likely to be missed by the 1% random sample, rendering the traces useless when they are needed most.
+
+The hyperscale architecture relies exclusively on Tail-Based Sampling. This approach delays the sampling decision until the entire trace has completed, allowing the system to intelligently retain 100% of traces containing errors or high latency while aggressively discarding successful, mundane requests. Implementing this at scale requires a complex, two-tier OpenTelemetry Collector architecture:
+
+1. **Agent Collectors (Tier 1):** The Data Plane gateways generate spans for all requests and send them to local Agent Collectors. These agents utilize a trace-aware load-balancing exporter.

--- a/docs/decisions/V1_IMPLEMENTATION_DECISIONS.md
+++ b/docs/decisions/V1_IMPLEMENTATION_DECISIONS.md
@@ -1,0 +1,109 @@
+# V1 Implementation Decisions & Frozen Choices
+
+## Overview
+
+For v1, the agent must implement a local-first API gateway with these non-negotiable choices:
+
+- **Data plane:** Envoy
+- **Custom code language:** Go
+- **Initial deployment model:** Docker Compose on 1 to 5 machines
+- **Config model:** file-based YAML, hot-reloaded by replacing files and restarting the container
+- **Service discovery:** static upstream lists in config for v1
+- **Auth:** JWT validation using JWKS
+- **Rate limiting:** Redis + Lua token bucket
+- **Observability:** Prometheus metrics, JSON access logs, optional OTEL trace export
+- **No control plane** in v1
+- **No Consul** in v1
+- **No xDS** in v1
+- **No hierarchical quota system** in v1
+- **No tail-based sampling** in v1
+
+This matches the MVP direction in your architecture docs and keeps the base case aligned with the local-first recommendation instead of jumping into hyperscale machinery too early.
+
+## V1 Request Path
+
+The gateway must support this minimal but complete request path:
+
+1. Accept HTTP request
+2. Match route by host + path prefix
+3. Optionally require JWT auth
+4. Optionally apply rate limit policy
+5. Proxy to configured upstream pool
+6. Emit structured access log
+7. Expose Prometheus metrics
+8. Return upstream response
+
+This stays faithful to the request lifecycle and edge responsibilities in the architecture docs, but trims away control-plane complexity.
+
+## Repository Structure
+
+Use this exact repo shape:
+
+```
+api-gateway/
+  README.md
+  Makefile
+  .env.example
+
+  configs/
+    gateway.yaml
+    envoy.yaml
+    jwks-dev.json
+
+  infra/
+    docker-compose.yml
+    prometheus.yml
+    redis.conf
+
+  services/
+    gateway-manager/
+      cmd/gateway-manager/main.go
+      internal/config/config.go
+      internal/jwks/jwks.go
+      internal/ratelimit/redis_lua.go
+      internal/admin/admin.go
+      internal/types/types.go
+      internal/validation/validation.go
+
+    echo-backend/
+      cmd/echo-backend/main.go
+
+  envoy/
+    envoy.yaml.tmpl
+    lua/
+      ratelimit.lua
+
+  scripts/
+    gen-jwt-dev.py
+    curl-smoke.sh
+    load-test.sh
+
+  tests/
+    config_validation_test.go
+    jwks_test.go
+    ratelimit_test.go
+    integration_test.go
+```
+
+### Role of Each Component
+
+**gateway-manager** exists because the base case still needs some glue logic that agents otherwise invent inconsistently. It owns:
+
+- Gateway config parsing
+- Config validation
+- JWKS fetch and cache
+- Redis rate limit helper behavior
+- Admin endpoints for health and reload status
+- Envoy config generation from your canonical YAML
+
+**Envoy** remains the data plane because the architecture docs already converge on reusing a hardened proxy rather than building parsing/TLS/proxying from scratch.
+
+## Rationale
+
+1. **MVP Focus:** V1 is intentionally minimal. It establishes the foundational patterns (JWT, rate limit, observability) without premature scaling machinery.
+2. **Future Evolution:** This structure cleanly evolves:
+   - Consul + gossip discovery can layer in later
+   - xDS servers can replace Envoy YAML templating
+   - Control plane can be introduced without rearchitecturing
+   - Hierarchical quota can migrate from single Redis
+3. **Implementability:** Each component is bounded and testable. Agents know exactly what success looks like.

--- a/examples/configs/gateway-single-node.yaml
+++ b/examples/configs/gateway-single-node.yaml
@@ -1,0 +1,77 @@
+version: 1
+
+gateway:
+  listen_address: "0.0.0.0:8080"
+  admin_address: "0.0.0.0:9090"
+  request_timeout_ms: 15000
+  idle_timeout_ms: 60000
+  max_request_body_bytes: 10485760
+  trust_forwarded_headers: false
+
+auth:
+  providers:
+    - name: "dev"
+      issuer: "https://dev.example.local/"
+      audience: "api-gateway"
+      jwks_uri: "http://host.docker.internal:7001/.well-known/jwks.json"
+      cache_ttl_seconds: 300
+      clock_skew_seconds: 30
+
+rate_limits:
+  redis_address: "redis:6379"
+  redis_db: 0
+  redis_key_prefix: "rl"
+  default_timeout_ms: 50
+  fail_open: false
+  survivability_mode:
+    enabled: true
+    fallback_capacity: 20
+    fallback_refill_rate_per_sec: 5
+
+routes:
+  - name: "public-echo"
+    hostnames: ["localhost", "127.0.0.1"]
+    path_prefix: "/public"
+    methods: ["GET", "POST"]
+    auth_required: false
+    rate_limit:
+      bucket_capacity: 100
+      refill_rate_per_sec: 20
+      key_by: "ip"
+    upstream:
+      service: "backend"
+      request_timeout_ms: 5000
+      retries: 1
+
+  - name: "private-echo"
+    hostnames: ["localhost", "127.0.0.1"]
+    path_prefix: "/private"
+    methods: ["GET", "POST"]
+    auth_required: true
+    auth_provider: "dev"
+    required_scopes: ["api.read"]
+    rate_limit:
+      bucket_capacity: 50
+      refill_rate_per_sec: 10
+      key_by: "sub"
+    upstream:
+      service: "backend"
+      request_timeout_ms: 5000
+      retries: 1
+
+services:
+  - name: "backend"
+    endpoints:
+      - "echo-backend:8081"
+    health_check:
+      path: "/healthz"
+      interval_ms: 2000
+      timeout_ms: 500
+
+observability:
+  access_log_json: true
+  prometheus_enabled: true
+  tracing:
+    enabled: false
+    otlp_endpoint: ""
+    sample_rate: 0.0

--- a/examples/single-node/README.md
+++ b/examples/single-node/README.md
@@ -1,0 +1,72 @@
+# Single-Node Deployment Example
+
+This example shows a minimal single-machine deployment of the API Gateway v1 for local development or small teams.
+
+## Architecture
+
+```
+[Client]
+    |
+    v
+[Gateway (Port 8080)]
+    |
+    +---> [Redis] (Port 6379)
+    +---> [Backend] (Port 8081)
+    +---> [JWKS Server] (Port 7001)
+```
+
+## Setup
+
+### Step 1: Copy Example Config
+
+```bash
+cp examples/single-node/gateway-single-node.yaml configs/gateway.yaml
+```
+
+### Step 2: Start Services
+
+```bash
+docker-compose -f examples/single-node/docker-compose.yml up -d
+```
+
+This starts:
+- `redis:7` — Rate limiting store
+- `gateway-manager` — Management and config loader
+- `envoy` — Data plane proxy
+- `echo-backend` — Demo upstream service
+- `fake-jwks` — Development JWKS server
+
+### Step 3: Generate a Dev JWT
+
+```bash
+python3 scripts/gen-jwt-dev.py --sub user-1 --scopes api.read > /tmp/token.jwt
+```
+
+### Step 4: Test the Gateway
+
+**Unprotected route:**
+
+```bash
+curl http://localhost:8080/public/echo -d '{"msg":"hello"}'
+```
+
+**Protected route (with JWT):**
+
+```bash
+TOKEN=$(cat /tmp/token.jwt)
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/private/echo -d '{"msg":"hello"}'
+```
+
+## Scale Considerations
+
+- **Single gateway instance** on one machine
+- **Single Redis instance** (no clustering)
+- **Static upstream endpoints** in config
+- **Suitable for:** 1-2 services, < 100 req/sec, local development
+
+## Next Steps
+
+- Add more routes to `gateway.yaml`
+- Configure health checks via `/readyz`
+- Monitor metrics at `http://localhost:9090/metrics`
+- See [../../deployments/docker-compose/](../../deployments/docker-compose/) for production multi-node setups

--- a/examples/single-node/docker-compose.yml
+++ b/examples/single-node/docker-compose.yml
@@ -1,0 +1,101 @@
+version: '3.9'
+
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: gateway-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    networks:
+      - gateway
+
+  echo-backend:
+    image: ealen/echo-server:latest
+    container_name: gateway-backend
+    environment:
+      PORT: 8081
+    ports:
+      - "8081:8081"
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8081/"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    networks:
+      - gateway
+
+  fake-jwks:
+    image: ghcr.io/navidstuart/fake-jwks-server:latest
+    container_name: gateway-jwks
+    ports:
+      - "7001:3000"
+    environment:
+      PRIVATE_KEY_PATH: /jwks/private.pem
+    volumes:
+      - ./jwks:/jwks
+    networks:
+      - gateway
+
+  gateway-manager:
+    build:
+      context: ../..
+      dockerfile: ./services/gateway-manager/Dockerfile
+    container_name: gateway-manager
+    ports:
+      - "8080:8080"
+      - "9090:9090"
+    volumes:
+      - ../../configs:/app/configs
+    environment:
+      GATEWAY_CONFIG_PATH: /app/configs/gateway.yaml
+      ENVOY_CONFIG_PATH: /app/configs/envoy.yaml
+      LOG_LEVEL: info
+    depends_on:
+      redis:
+        condition: service_healthy
+      echo-backend:
+        condition: service_healthy
+    networks:
+      - gateway
+
+  envoy:
+    image: envoyproxy/envoy:v1.31-latest
+    container_name: gateway-envoy
+    ports:
+      - "80:10000"
+    volumes:
+      - ../../configs/envoy.yaml:/etc/envoy/envoy.yaml
+    command: /usr/local/bin/envoy -c /etc/envoy/envoy.yaml
+    depends_on:
+      - gateway-manager
+    networks:
+      - gateway
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: gateway-prometheus
+    ports:
+      - "9091:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+    networks:
+      - gateway
+
+volumes:
+  redis_data:
+  prometheus_data:
+
+networks:
+  gateway:
+    driver: bridge

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,79 @@
+# Scripts Directory
+
+This directory contains low-ceremony helper scripts for development and testing.
+
+## Available Scripts
+
+### `gen-jwt-dev.py`
+
+Generate JWT tokens for local development and testing.
+
+**Usage:**
+
+```bash
+# Generate a token for user-1 with api.read scope
+python3 scripts/gen-jwt-dev.py --sub user-1 --scopes api.read
+
+# With multiple scopes
+python3 scripts/gen-jwt-dev.py --sub user-2 --scopes "api.read api.write"
+
+# Show decoded token
+python3 scripts/gen-jwt-dev.py --sub user-1 --decode
+
+# Set expiration to 1 hour
+python3 scripts/gen-jwt-dev.py --sub user-1 --hours 1
+```
+
+**Options:**
+
+- `--sub` — JWT subject (user ID). Default: `test-user`
+- `--scopes` — Space-separated scopes. Default: none
+- `--issuer` — JWT issuer URL. Default: `https://dev.example.local/`
+- `--audience` — JWT audience. Default: `api-gateway`
+- `--hours` — Token expiration. Default: 24 hours
+- `--decode` — Print decoded token (for inspection)
+
+**Output:** Raw JWT token (suitable for piping to curl or environment variables)
+
+### `smoke-test.sh`
+
+Basic smoke tests for gateway functionality.
+
+**Usage:**
+
+```bash
+# Run against localhost (default)
+./scripts/smoke-test.sh
+
+# Run against remote gateway
+GATEWAY_URL=https://api.example.com ./scripts/smoke-test.sh
+```
+
+**Tests:**
+- Public route without auth
+- Protected route without auth (should fail)
+- Protected route with valid JWT
+- Admin /healthz endpoint
+- Admin /readyz endpoint
+- Admin /metrics endpoint
+
+**Requirements:**
+- `curl` — HTTP client
+- `python3` — For JWT generation
+- Gateway running and accessible
+
+## Contributing
+
+When adding new scripts:
+
+1. Keep them practical and low-ceremony
+2. Add a header comment explaining purpose
+3. Include usage examples
+4. Add this README entry
+5. No important logic should live only in scripts — they're helpers, not core
+
+## Further Reading
+
+- [../deployments/docker-compose/](../deployments/docker-compose/) — Deployment automation
+- [../examples/](../examples/) — Example configurations
+- [../specs/](../specs/) — Specification details

--- a/scripts/gen-jwt-dev.py
+++ b/scripts/gen-jwt-dev.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Generate a development JWT token for local testing.
+
+Usage:
+    python3 gen-jwt-dev.py --sub user-1 --scopes api.read,api.write
+    python3 gen-jwt-dev.py --help
+"""
+
+import json
+import sys
+import jwt
+import argparse
+from datetime import datetime, timedelta
+from pathlib import Path
+
+# Default development private key (insecure, dev only)
+DEV_PRIVATE_KEY = """-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA0Z3VS5JJcds6lJ3ExHGNpBq29cN2UGr0Sp5UM7c/Z6V5tOLg
+XrQStkzJAa7vxNwuZp5l+sRLqVZFv0yLxMYAP+cL0gC5Jq0eKxDxMvN0eHjYZdKR
+GYKMvN8jqZrU7hXCKNkKPpJGlYKyPpJmP9jzYrVqYrV5YrVqYrV5YrVqYrV5Yrv1
+qYrV5YrVqYrV5YrVqYrV5YrVqYrV5YrVqYrV5YrVqYrV5YrVqYrV5YrVqYrV5YrV
+qYrV5YrVqYrVQIDAQABAoIBADw9LzXMQ7NmvvvP0HxZnXjAKdkXuUx9J/5q0Fxf
+qyEqK1+KQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVzQVyqKQVyqKQV
+yqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqK
+QVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVy
+qKQVyqKQVyqKQV1DZnZQlAECgYEA8xVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyq
+KQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQV
+yqKQVyqKQVyqKQV1DZnZQlAECgYEA8xVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyq
+KQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQV1DZnZQlAECgYEA8xVyqK
+QVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQV1DZnZQlAECgYEA8xVyqKQ
+VyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQV1DZnZQlAECgYEA8xVyqKQVyqKQV
+yqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQV1DZnZQlAECgYEA8xVyqKQVyqKQVy
+qKQVyqKQV1DZnZQlAECgYEA8xVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQVyq
+KQVyqKQVyqKQVyqKQV1DZnZQlAECgYEA8xVyqKQVyqKQVyqKQVyqKQVyqKQVyqK
+QVyqKQVyqKQVyqKQVyqKQVyqKQVyqKQV1DZnZQlAC8=
+-----END RSA PRIVATE KEY-----"""
+
+def generate_jwt(subject, scopes=None, expires_in_hours=24, issuer="https://dev.example.local/", audience="api-gateway"):
+    """Generate a JWT token."""
+    
+    now = datetime.utcnow()
+    payload = {
+        "sub": subject,
+        "iss": issuer,
+        "aud": [audience],
+        "iat": int(now.timestamp()),
+        "nbf": int(now.timestamp()),
+        "exp": int((now + timedelta(hours=expires_in_hours)).timestamp()),
+    }
+    
+    if scopes:
+        payload["scope"] = scopes if isinstance(scopes, str) else " ".join(scopes)
+        payload["scp"] = scopes.split() if isinstance(scopes, str) else scopes
+    
+    token = jwt.encode(payload, DEV_PRIVATE_KEY, algorithm="RS256", headers={"kid": "dev-key-1"})
+    return token
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate a development JWT token for testing"
+    )
+    parser.add_argument("--sub", default="test-user", help="JWT subject (default: test-user)")
+    parser.add_argument("--scopes", help="Space-separated scopes (e.g., 'api.read api.write')")
+    parser.add_argument("--issuer", default="https://dev.example.local/", help="JWT issuer")
+    parser.add_argument("--audience", default="api-gateway", help="JWT audience")
+    parser.add_argument("--hours", type=int, default=24, help="Token expiration in hours")
+    parser.add_argument("--decode", action="store_true", help="Print decoded token instead of raw JWT")
+    
+    args = parser.parse_args()
+    
+    try:
+        token = generate_jwt(
+            subject=args.sub,
+            scopes=args.scopes,
+            expires_in_hours=args.hours,
+            issuer=args.issuer,
+            audience=args.audience
+        )
+        
+        if args.decode:
+            decoded = jwt.decode(token, options={"verify_signature": False})
+            print(json.dumps(decoded, indent=2))
+        else:
+            print(token)
+    
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Smoke test for the API Gateway
+# Validates basic functionality: routing, auth, rate limiting
+
+set -e
+
+GATEWAY_URL="${GATEWAY_URL:-http://localhost:8080}"
+TOKEN_SCRIPT="$(dirname "$0")/gen-jwt-dev.py"
+
+echo "=== API Gateway Smoke Tests ==="
+echo "Gateway URL: $GATEWAY_URL"
+echo ""
+
+# Generate test token
+echo "Generating test JWT..."
+TOKEN=$(python3 "$TOKEN_SCRIPT" --sub test-user --scopes "api.read api.write")
+echo "Token: ${TOKEN:0:50}..."
+echo ""
+
+# Test 1: Public route (no auth)
+echo "Test 1: Public route (no auth required)"
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$GATEWAY_URL/public/echo" \
+  -H "Content-Type: application/json" \
+  -d '{"msg":"hello"}')
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+BODY=$(echo "$RESPONSE" | head -n-1)
+
+if [ "$HTTP_CODE" == "200" ]; then
+  echo "✓ PASS (HTTP $HTTP_CODE)"
+else
+  echo "✗ FAIL (HTTP $HTTP_CODE)"
+  echo "Response: $BODY"
+  exit 1
+fi
+echo ""
+
+# Test 2: Protected route without auth
+echo "Test 2: Protected route without auth (should be 401)"
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$GATEWAY_URL/private/echo" \
+  -H "Content-Type: application/json" \
+  -d '{"msg":"hello"}')
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+
+if [ "$HTTP_CODE" == "401" ]; then
+  echo "✓ PASS (HTTP $HTTP_CODE)"
+else
+  echo "✗ FAIL (HTTP $HTTP_CODE, expected 401)"
+  exit 1
+fi
+echo ""
+
+# Test 3: Protected route with valid JWT
+echo "Test 3: Protected route with valid JWT"
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$GATEWAY_URL/private/echo" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"msg":"hello"}')
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+
+if [ "$HTTP_CODE" == "200" ]; then
+  echo "✓ PASS (HTTP $HTTP_CODE)"
+else
+  echo "✗ FAIL (HTTP $HTTP_CODE)"
+  exit 1
+fi
+echo ""
+
+# Test 4: Admin health check
+echo "Test 4: Admin /healthz endpoint"
+RESPONSE=$(curl -s -w "\n%{http_code}" http://localhost:9090/healthz)
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+
+if [ "$HTTP_CODE" == "200" ]; then
+  echo "✓ PASS (HTTP $HTTP_CODE)"
+else
+  echo "✗ FAIL (HTTP $HTTP_CODE)"
+  exit 1
+fi
+echo ""
+
+# Test 5: Admin readyz check
+echo "Test 5: Admin /readyz endpoint"
+RESPONSE=$(curl -s -w "\n%{http_code}" http://localhost:9090/readyz)
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+
+if [ "$HTTP_CODE" == "200" ]; then
+  echo "✓ PASS (HTTP $HTTP_CODE)"
+else
+  echo "⚠ WARN (HTTP $HTTP_CODE - gateway may not be fully ready)"
+fi
+echo ""
+
+# Test 6: Metrics endpoint
+echo "Test 6: Admin /metrics endpoint"
+RESPONSE=$(curl -s -w "\n%{http_code}" http://localhost:9090/metrics)
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+
+if [ "$HTTP_CODE" == "200" ]; then
+  echo "✓ PASS (HTTP $HTTP_CODE)"
+else
+  echo "✗ FAIL (HTTP $HTTP_CODE)"
+  exit 1
+fi
+echo ""
+
+echo "=== All Smoke Tests Passed ==="

--- a/specs/admin-api.md
+++ b/specs/admin-api.md
@@ -1,0 +1,260 @@
+# Admin API Specification
+
+This document specifies the Admin API contract for the API Gateway v1. The Admin API runs on a separate port (default `:9090`) and is NOT exposed to clients; it is only for operational and monitoring purposes.
+
+## Overview
+
+The Admin API provides:
+
+1. **Health checks** — Is the gateway alive?
+2. **Readiness checks** — Is the gateway ready to serve traffic?
+3. **Config status** — What config is active? When was it last reloaded?
+4. **Config reload trigger** — Reload configuration from disk
+
+All responses are JSON.
+
+---
+
+## Endpoints
+
+### `GET /healthz`
+
+**Live Check:** Is the gateway process alive?
+
+**Response:** 200 OK
+
+```json
+{
+  "ok": true
+}
+```
+
+**Usage:** Use this for Kubernetes liveness probes, Docker health checks, or uptime monitoring.
+
+**Behavior:**
+- Returns 200 immediately if the process is running
+- No expensive checks
+- Fails only if the process crashes
+
+---
+
+### `GET /readyz`
+
+**Ready Check:** Is the gateway ready to serve traffic?
+
+**Response:** 200 OK (if ready) or 503 Service Unavailable (if not ready)
+
+```json
+{
+  "ok": true,
+  "config_loaded": true,
+  "redis_ok": true,
+  "jwks_ok": true,
+  "last_config_reload_unix": 1760000000
+}
+```
+
+**Fields:**
+
+| Field | Type | Description |
+| :---- | :---- | :---- |
+| `ok` | boolean | `true` if all checks pass; `false` if any check fails |
+| `config_loaded` | boolean | `true` if gateway config has been loaded successfully |
+| `redis_ok` | boolean | `true` if Redis connectivity is healthy (checked on-demand or cached) |
+| `jwks_ok` | boolean | `true` if at least one JWKS provider is reachable (best-effort check) |
+| `last_config_reload_unix` | integer | Unix timestamp of the last successful config reload |
+
+**Status Code Logic:**
+- **200 OK:** `ok: true` (all checks pass)
+- **503 Service Unavailable:** `ok: false` (one or more checks fail)
+
+**Usage:** Use this for Kubernetes readiness probes, load balancer health checks, or to decide whether to route traffic to this gateway instance.
+
+**Readiness Criteria:**
+1. Config loaded at least once (required)
+2. Redis is reachable (if rate limiting is enabled; can be degraded)
+3. At least one JWKS provider is reachable (if auth is used; can be cached)
+
+**Notes:**
+- `redis_ok` can be `false` if Redis is unreachable, but degraded mode is active; request processing continues
+- `jwks_ok` can be `false` if all JWKS endpoints are stale (cache age > 10 × TTL); protected routes return 503
+
+---
+
+### `GET /config/status`
+
+**Config Status:** What config is currently active?
+
+**Response:** 200 OK
+
+```json
+{
+  "active_config_version": 1,
+  "active_config_sha256": "abc123def456...",
+  "last_reload_result": "success",
+  "last_reload_error": null,
+  "last_reload_unix": 1760000000
+}
+```
+
+**Fields:**
+
+| Field | Type | Description |
+| :---- | :---- | :---- |
+| `active_config_version` | integer | Config version from `configs/gateway.yaml` (top-level `version:` field) |
+| `active_config_sha256` | string | SHA256 hash of the active config file (for drift detection) |
+| `last_reload_result` | string | `success` or `validation_error` |
+| `last_reload_error` | string or null | Error message if `last_reload_result: validation_error`; `null` if success |
+| `last_reload_unix` | integer | Unix timestamp of the last reload attempt |
+
+**Usage:** Detect config drift, verify active config, troubleshoot reload failures.
+
+**Example (Failure):**
+
+```json
+{
+  "active_config_version": 1,
+  "active_config_sha256": "old_hash...",
+  "last_reload_result": "validation_error",
+  "last_reload_error": "route 'api' specifies non-existent upstream service 'backend2'",
+  "last_reload_unix": 1760000000
+}
+```
+
+---
+
+### `POST /config/reload`
+
+**Trigger Config Reload:** Reload `configs/gateway.yaml`, validate it, and swap to the new config if valid.
+
+**Request:** No body required.
+
+```
+POST /config/reload
+```
+
+**Response:** 200 OK (if reload succeeds) or 400 Bad Request (if validation fails)
+
+**Success Response (200 OK):**
+
+```json
+{
+  "ok": true,
+  "message": "config reloaded successfully",
+  "previous_sha256": "old_hash...",
+  "new_sha256": "new_hash...",
+  "reload_timestamp": 1760000000
+}
+```
+
+**Failure Response (400 Bad Request):**
+
+```json
+{
+  "ok": false,
+  "message": "config validation failed",
+  "error": "route 'api' specifies non-existent upstream service 'backend2'",
+  "reload_timestamp": 1760000000
+}
+```
+
+**Behavior:**
+
+1. Read `configs/gateway.yaml` from disk
+2. Parse YAML
+3. Validate against schema (see [../specs/config-schema.md](../specs/config-schema.md))
+4. If validation passes:
+   - Generate new Envoy config from the gateway config
+   - Swap to the new config (atomically in memory)
+   - Restart Envoy container or signal the data plane (implementation-dependent)
+   - Return 200 OK with new config hash
+5. If validation fails:
+   - Keep the old config active
+   - Return 400 with error details
+   - Log the error
+
+**In-Flight Request Handling:**
+
+- **During swap:** Existing requests continue using the old config
+- **New requests:** Use the new config immediately after swap
+- **No request drops:** The swap is atomic; no requests are dropped
+- **Envoy restart:** May cause brief (< 1 second) connection drains; clients should retry
+
+**Usage:**
+
+```bash
+# Validate a new config
+curl -X POST http://localhost:9090/config/reload
+
+# Check result
+curl http://localhost:9090/config/status
+```
+
+---
+
+## Error Responses
+
+All error responses include:
+
+| Field | Type | Description |
+| :---- | :---- | :---- |
+| `ok` | boolean | `false` (indicates error) |
+| `message` | string | Human-readable error summary |
+| `error` | string | Detailed error message (if available) |
+
+### Possible Error Codes
+
+| Error | Status | Reason |
+| :---- | :---- | :---- |
+| `config_not_found` | 400 | `configs/gateway.yaml` does not exist |
+| `config_parse_error` | 400 | YAML parsing failed (invalid syntax) |
+| `validation_error` | 400 | Config validation failed (schema mismatch, missing fields, invalid values) |
+| `io_error` | 500 | Unexpected I/O error reading/writing config |
+| `internal_error` | 500 | Unexpected internal error |
+
+---
+
+## Authentication & Security
+
+**Important:** The Admin API is NOT authenticated by default.
+
+- **Deployment Model:** Admin port (`:9090`) must NOT be exposed to the internet
+- **Network Policy:** Restrict access to admin port to trusted operators only (firewall, network policies, Kubernetes NetworkPolicy)
+- **v1 Scope:** Authentication for admin API is out of scope for v1
+
+---
+
+## Monitoring & Alerting
+
+Recommended metrics:
+
+| Metric | Alert Threshold | Action |
+| :---- | :---- | :---- |
+| `readyz` returns 503 | Any occurrence | Investigate config, Redis, or JWKS availability |
+| `/config/reload` returns 400 | Any occurrence | Review error message; fix config and retry |
+| `last_config_reload_unix` is stale | > 1 day old (no reload in 24h) | Normal (unless you expect frequent changes) |
+| `last_reload_result: validation_error` | Persistent | Fix config and retry reload |
+
+---
+
+## Testing Checklist
+
+- [ ] `/healthz` returns 200 with `{"ok":true}` when process is running
+- [ ] `/readyz` returns 200 when config is loaded and Redis is reachable
+- [ ] `/readyz` returns 503 when config is invalid or Redis is unreachable (if required)
+- [ ] `/config/status` returns current config version and SHA256
+- [ ] `/config/status` returns error details if last reload failed
+- [ ] `POST /config/reload` validates config before swapping
+- [ ] `POST /config/reload` returns 400 with error details on validation failure
+- [ ] After successful reload, new config is active (new routes work, old routes may fail)
+- [ ] In-flight requests complete normally during config swap (no drops)
+- [ ] Config reload is atomic (no partial updates)
+- [ ] Admin API is NOT accessible from the public gateway port
+
+---
+
+## Further Reading
+
+- [base-case-implementation-spec.md](base-case-implementation-spec.md) — Admin API overview
+- [config-schema.md](config-schema.md) — Configuration validation rules
+- [../../docs/operations/](../../docs/operations/) — Operational runbooks

--- a/specs/auth.md
+++ b/specs/auth.md
@@ -1,0 +1,179 @@
+# Authentication (JWT/JWKS) Specification
+
+This document specifies the exact JWT validation contract for the API Gateway v1.
+
+## Overview
+
+The gateway accepts JWTs as the single source of authentication for protected routes. JWTs are validated using public keys fetched from a JWKS endpoint, enabling completely stateless authentication without external database lookups on the hot path.
+
+## Token Source
+
+Only the `Authorization` header is accepted in v1:
+
+```
+GET /protected/data HTTP/1.1
+Authorization: Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6ImtleTEifQ...
+```
+
+- **Cookie-based auth is not supported in v1**
+- **Multiple auth schemes are not supported in v1**
+- **Malformed authorization headers result in 401 Unauthorized**
+
+## Full Validation Rules
+
+A JWT is valid **only if all** of these conditions hold:
+
+1. **Token Format**
+   - Must be in format: `Bearer <jwt>`
+   - JWT must be well-formed (three base64 segments separated by dots)
+   - If malformed, return 401
+
+2. **Header Claims**
+   - `alg` must be exactly `RS256` in v1 (no HS256, no ECDSA, etc.)
+   - `kid` must be present and must exist in current JWKS
+   - If `kid` is unknown and a refresh is triggered, retry once after JWKS fetch
+   - If `kid` still unknown after refresh, return 401
+
+3. **Signature Verification**
+   - Token signature must verify against the JWKS key identified by `kid`
+   - If verification fails, return 401
+
+4. **Issuer & Audience**
+   - `iss` claim must match config's `auth.providers[].issuer` exactly (string comparison, case-sensitive)
+   - `aud` must be an array (or string convertible to single-element array) and must contain the config's `auth.providers[].audience`
+   - If either fails, return 401
+
+5. **Time Windows** (with configured `clock_skew_seconds`)
+   - Current UTC time must be >= `nbf` claim - `clock_skew_seconds`
+   - Current UTC time must be < `exp` claim + `clock_skew_seconds`
+   - If either fails, return 401
+
+6. **Scopes (if route requires them)**
+   - If the route defines `required_scopes: [scope1, scope2]`, the JWT must contain a `scope` or `scp` claim
+   - The claim must be either:
+     - A space-separated string: `"scope1 scope2 scope3"`
+     - A JSON array: `["scope1", "scope2", "scope3"]`
+   - The token must contain **all** required scopes (intersection check)
+   - If any required scope is missing, return 403 Forbidden
+
+## JWKS Caching & Refresh
+
+The gateway caches JWKS responses locally to avoid hammering the external identity provider on every request.
+
+### Cache Behavior
+
+1. **On Startup:** Fetch JWKS immediately and cache it
+2. **During Operation:**
+   - Return cached JWKS for all lookups
+   - Every `cache_ttl_seconds`, refresh JWKS in background (non-blocking)
+   - If a request arrives with an unknown `kid`:
+     - Immediately trigger a refresh (non-blocking if already in-flight)
+     - Fall through to using old cache
+3. **Cache Stale Threshold:** 10 × `cache_ttl_seconds`
+   - If refresh fails repeatedly and cache age exceeds this threshold:
+     - **Protected routes** return 503 Service Unavailable with body `{"error":"auth_provider_unavailable"}`
+     - **Unprotected routes** continue normally
+4. **Refresh Failure Handling:**
+   - Log the error but do not block ongoing requests
+   - Continue using last known-good cache
+
+### Example Timeline
+
+```
+t=0s:     JWKS fetch succeeds. Cache TTL = 300s.
+t=100s:   Request with unknown kid arrives.
+          - Issue refresh request (non-blocking)
+          - Use old cache for current request
+          - If old cache has the kid, validation succeeds
+          - If old cache missing the kid, try refresh result
+t=300s:   Background refresh triggers (scheduled)
+t=3000s:  Cache age = 3000s. If refresh has been failing for 2700s+
+          (i.e., 9 × 300s), and next protected request arrives:
+          - Return 503 auth_provider_unavailable
+```
+
+## Extracted Identity
+
+After a JWT passes all validation checks, the gateway normalizes the identity to this canonical structure (used for rate-limit keying and header injection):
+
+```json
+{
+  "sub": "user-123",
+  "iss": "https://auth.example.local/",
+  "aud": ["api-gateway"],
+  "scopes": ["api.read", "api.write"],
+  "exp_unix": 1760000000
+}
+```
+
+Notes:
+- `sub` (subject) is the user identifier. **If missing from JWT, validation fails (return 401).**
+- `aud` is normalized to a list internally
+- `scopes` is derived from `scope` or `scp` claim (space-delimited string or array), or empty list if not present
+- `exp_unix` is the `exp` claim (Unix seconds)
+
+## Forwarded Headers
+
+If authentication succeeds, the gateway injects these headers into the upstream request:
+
+```
+x-auth-sub: user-123
+x-auth-iss: https://auth.example.local/
+x-auth-scopes: api.read,api.write
+x-request-id: <uuid>
+traceparent: <w3c trace context>    # Only if tracing enabled
+```
+
+**Do NOT forward the raw JWT or the raw decoded claims blob to upstream services.**
+
+## Rate-Limit Keying
+
+Protected routes with `rate_limit.key_by: "sub"` rate-limit by the JWT's `sub` claim. The rate-limit key in Redis is:
+
+```
+rl:{route_name}:sub:{sub_claim_value}
+```
+
+E.g., `rl:private-echo:sub:user-123`.
+
+## Error Responses
+
+| Condition | Status | Body |
+| :---- | :---- | :---- |
+| No Authorization header | 401 | `{"error":"missing_token"}` |
+| Malformed Bearer token | 401 | `{"error":"invalid_token_format"}` |
+| Token parsing fails (JWT malformed) | 401 | `{"error":"invalid_token"}` |
+| `alg` is not RS256 | 401 | `{"error":"unsupported_algorithm"}` |
+| `kid` unknown and refresh fails | 401 | `{"error":"unknown_key_id"}` |
+| Signature verification fails | 401 | `{"error":"invalid_signature"}` |
+| `iss` mismatch | 401 | `{"error":"invalid_issuer"}` |
+| `aud` mismatch | 401 | `{"error":"invalid_audience"}` |
+| Token expired (`exp` check failed) | 401 | `{"error":"token_expired"}` |
+| Token not yet valid (`nbf` check failed) | 401 | `{"error":"token_not_yet_valid"}` |
+| Required scope missing | 403 | `{"error":"insufficient_scopes"}` |
+| JWKS provider unavailable (cache stale) | 503 | `{"error":"auth_provider_unavailable"}` |
+| `sub` claim missing | 401 | `{"error":"missing_subject"}` |
+
+All error responses include a `content-type: application/json` header.
+
+## Testing Checklist
+
+- [ ] Valid RS256 JWT with matching iss, aud, nbf, exp passes validation
+- [ ] Token with wrong `alg` (HS256) is rejected with 401
+- [ ] Token with unknown `kid` triggers refresh; if refresh succeeds and key exists, validation passes
+- [ ] Token with unknown `kid` after refresh fails with 401
+- [ ] Expired token is rejected with 401
+- [ ] Token not yet valid (nbf in future) is rejected with 401
+- [ ] Token with wrong `iss` is rejected with 401
+- [ ] Token with wrong `aud` is rejected with 401
+- [ ] Token missing required scope is rejected with 403
+- [ ] Valid token injects all required headers into upstream request
+- [ ] JWKS cache TTL refresh works correctly
+- [ ] JWKS cache stale threshold (10×TTL) returns 503 for protected routes
+- [ ] `sub` claim in token is used for rate-limit keying when `key_by: sub`
+
+## Further Reading
+
+- [config-schema.md](config-schema.md) — Auth provider configuration
+- [rate-limiting.md](rate-limiting.md) — Rate limit keying with `key_by: sub`
+- [observability.md](observability.md) — Metrics for auth failures

--- a/specs/base-case-implementation-spec.md
+++ b/specs/base-case-implementation-spec.md
@@ -1,0 +1,144 @@
+# Base Case Implementation Specification
+
+This document specifies the canonical, reference implementation of the API Gateway v1.
+
+## Executive Summary
+
+The v1 gateway is a local-first, production-grade API Gateway that serves as the critical ingress boundary for microservices architectures on 1-5 node clusters. It provides:
+
+- **Request routing** by hostname and longest-prefix path match
+- **Stateless authentication** via JWT + JWKS
+- **Rate limiting** via Redis + Token Bucket algorithm
+- **Observability** via Prometheus metrics and JSON access logs
+- **Graceful failure** with degraded-mode fallbacks
+
+## Request Lifecycle
+
+Every request follows this deterministic pipeline:
+
+1. **TLS Termination** — Envoy accepts TCP, negotiates TLS
+2. **HTTP Parsing** — Raw bytes → HTTP representation with header normalization
+3. **Route Match** — Hostname exact match, longest path prefix wins
+4. **Method Check** — Verify HTTP method is allowed for route
+5. **Authentication** — If route requires auth, validate JWT (see [auth.md](auth.md))
+6. **Rate Limit Check** — If route has rate limit policy, check Redis token bucket (see [rate-limiting.md](rate-limiting.md))
+7. **Upstream Selection** — Pick healthy endpoint from route's upstream service
+8. **Proxy** — Forward request, stream response
+9. **Observability** — Emit access log and metrics (see [observability.md](observability.md))
+
+## Key Design Decisions
+
+### Why Envoy as Data Plane?
+
+- Hardened, production-tested proxy (avoids building TLS, HTTP/2, QUIC from scratch)
+- Can eventually evolve to xDS without rearchitecture
+- Stable, well-understood failure modes
+- Strong operational tooling
+
+### Why File-Based Config, Not xDS?
+
+- Eliminates control-plane complexity for v1
+- Still provides atomic config updates (validate, write, restart or reload safely)
+- Trivial to layer xDS on top later (gateway-manager → xDS server)
+- Agents have clear success criteria
+
+### Why JWT, Not Session Cookies?
+
+- Completely stateless validation (CPU-only, no database lookups)
+- Scales from 1 node to hyperscale without architectural change
+- JWKS caching eliminates hard dependency on external IdP
+- Clear failure modes (expired token = 401, untrusted signature = 401)
+
+### Why Redis + Lua for Rate Limiting?
+
+- Atomic, race-condition-free token bucket logic via Lua atomicity
+- Single point of truth ensures fair distribution across replicas
+- Graceful degradation: if Redis fails, fall back to local in-memory bucket
+- Scales from 1 Redis instance to sharded cluster without code changes
+
+## Config Model
+
+The canonical config for v1 is `configs/gateway.yaml`. See [config-schema.md](config-schema.md) for the full schema, validation rules, and examples.
+
+## Admin API
+
+The gateway exposes a lightweight admin API on `:9090` (separate from the gateway port). See [admin-api.md](admin-api.md) for the full specification.
+
+## Deployment Model
+
+For v1, the standard deployment is:
+
+```yaml
+services:
+  redis:
+    image: redis:7
+    ports: ["6379:6379"]
+
+  echo-backend:  # placeholder upstream 
+    build: ./services/echo-backend
+    ports: ["8081:8081"]
+
+  gateway-manager:
+    build: ./services/gateway-manager
+    ports:
+      - "8080:8080"     # Gateway port
+      - "9090:9090"     # Admin port
+    volumes:
+      - ./configs:/app/configs
+
+  envoy:
+    image: envoyproxy/envoy:v1.31-latest
+    ports:
+      - "80:10000"      # HTTP egress from Envoy
+      - "443:10001"     # HTTPS egress (optional)
+    volumes:
+      - ./configs/envoy.yaml:/etc/envoy/envoy.yaml
+```
+
+See [../examples/docker-compose/](../examples/docker-compose/) and [../../deployments/docker-compose/](../../deployments/docker-compose/) for complete examples.
+
+## Observability Contract
+
+The gateway emits:
+
+- **Access logs** (JSON, stdout): Every request
+- **Prometheus metrics** (HTTP /metrics): Scraped every 15-30 seconds
+- **Distributed traces** (optional OTLP): If `tracing.enabled: true` in config
+
+See [observability.md](observability.md) for detailed schemas.
+
+## Failure Modes & Mitigations
+
+| Failure | Behavior | Mitigation |
+| :---- | :---- | :---- |
+| Redis unavailable | Rate limiter times out | Fall back to local in-memory token bucket, emit `x-rate-limit-mode: degraded-local` |
+| JWKS fetch fails | Use cached JWKS | If cache age > 10 * cache_ttl_seconds, deny protected routes with 503 |
+| Upstream unavailable | No healthy endpoints | Return 503 with `{"error":"upstream_unavailable"}` |
+| Gateway overloaded | > 1000 concurrent requests | Return 503 with `x-gateway-overloaded: true` and `retry-after: 1` |
+| Config invalid | Reject load | Keep last known-good config, expose error via admin `/config/status` |
+
+## Testing Strategy
+
+V1 requires these test categories:
+
+1. **Config validation tests** — Invalid schemas, missing fields, type mismatches
+2. **JWT tests** — Valid/expired/malformed/wrong-signature tokens
+3. **Rate limit tests** — Token bucket behavior, Redis failures, local fallback
+4. **Route matching tests** — Host/path/method ordering and precedence
+5. **Integration tests** — End-to-end request flow with mock backends
+
+See [../../tests/](../../tests/) for the test structure.
+
+## Success Criteria
+
+A correct v1 implementation:
+
+- [ ] Routes requests by host + path according to longest-prefix-match order
+- [ ] Validates JWTs using JWKS and enforces required scopes
+- [ ] Rate-limits requests via Redis token bucket with atomic Lua execution
+- [ ] Falls back to in-memory token bucket if Redis is unavailable
+- [ ] Emits structured JSON access logs with all required fields
+- [ ] Exposes Prometheus metrics with bounded cardinality (no raw paths/user IDs)
+- [ ] Handles auth/JWKS/rate-limit/upstream failures gracefully with appropriate status codes
+- [ ] Reloads config atomically without dropping in-flight requests
+- [ ] Passes all config validation, unit, and integration tests

--- a/specs/config-schema.md
+++ b/specs/config-schema.md
@@ -1,0 +1,272 @@
+# Configuration Schema Specification
+
+This document defines the canonical YAML config schema for the API Gateway v1. Generator agents must produce configs conforming to this exact schema.
+
+## Config File Location
+
+`configs/gateway.yaml` is the source-of-truth configuration.
+
+## Root-Level Schema
+
+```yaml
+version: 1
+
+gateway:
+  # Gateway server configuration
+  listen_address: "0.0.0.0:8080"
+  admin_address: "0.0.0.0:9090"
+  request_timeout_ms: 15000
+  idle_timeout_ms: 60000
+  max_request_body_bytes: 10485760
+  trust_forwarded_headers: false
+
+auth:
+  providers:
+    - name: "main"
+      issuer: "https://auth.example.local/"
+      audience: "api-gateway"
+      jwks_uri: "http://host.docker.internal:7001/.well-known/jwks.json"
+      cache_ttl_seconds: 300
+      clock_skew_seconds: 30
+
+rate_limits:
+  redis_address: "redis:6379"
+  redis_db: 0
+  redis_key_prefix: "rl"
+  default_timeout_ms: 50
+  fail_open: false
+  survivability_mode:
+    enabled: true
+    fallback_capacity: 20
+    fallback_refill_rate_per_sec: 5
+
+routes:
+  - name: "public-echo"
+    hostnames: ["localhost"]
+    path_prefix: "/public"
+    methods: ["GET", "POST"]
+    auth_required: false
+    rate_limit:
+      bucket_capacity: 50
+      refill_rate_per_sec: 10
+      key_by: "ip"
+    upstream:
+      service: "echo-public"
+      request_timeout_ms: 5000
+      retries: 1
+
+services:
+  - name: "echo-public"
+    endpoints:
+      - "echo-backend:8081"
+    health_check:
+      path: "/healthz"
+      interval_ms: 2000
+      timeout_ms: 500
+
+observability:
+  access_log_json: true
+  prometheus_enabled: true
+  tracing:
+    enabled: false
+    otlp_endpoint: ""
+    sample_rate: 0.0
+```
+
+## Detailed Field Specifications
+
+### gateway
+
+| Field | Type | Required | Default | Description |
+| :---- | :---- | :---- | :---- | :---- |
+| `listen_address` | string | yes | — | Address and port the gateway listens on (e.g., `0.0.0.0:8080`) |
+| `admin_address` | string | yes | — | Address and port the admin API listens on (e.g., `0.0.0.0:9090`) |
+| `request_timeout_ms` | integer | yes | 15000 | Global timeout for client requests (milliseconds) |
+| `idle_timeout_ms` | integer | yes | 60000 | Timeout for idle connections (milliseconds) |
+| `max_request_body_bytes` | integer | yes | 10485760 | Maximum allowed request body size (10 MB default) |
+| `trust_forwarded_headers` | boolean | yes | false | Whether to trust X-Forwarded-* headers from clients |
+
+### auth.providers[]
+
+| Field | Type | Required | Default | Description |
+| :---- | :---- | :---- | :---- | :---- |
+| `name` | string | yes | — | Unique name for this auth provider (referenced by routes) |
+| `issuer` | string | yes | — | Expected JWT `iss` claim (must match exactly) |
+| `audience` | string | yes | — | Expected JWT `aud` claim |
+| `jwks_uri` | string | yes | — | URL to fetch JWKS from (must be reachable from gateway) |
+| `cache_ttl_seconds` | integer | yes | 300 | How long to cache JWKS before refreshing |
+| `clock_skew_seconds` | integer | yes | 30 | Clock skew tolerance for `nbf` and `exp` validation |
+
+### rate_limits
+
+| Field | Type | Required | Default | Description |
+| :---- | :---- | :---- | :---- | :---- |
+| `redis_address` | string | yes | — | Redis address:port |
+| `redis_db` | integer | yes | 0 | Redis database number |
+| `redis_key_prefix` | string | yes | "rl" | Prefix for all rate limit keys in Redis |
+| `default_timeout_ms` | integer | yes | 50 | Timeout for Redis operations (milliseconds) |
+| `fail_open` | boolean | yes | false | If true, allow requests when rate limiter unavailable |
+| `survivability_mode.enabled` | boolean | yes | true | Enable local fallback when Redis is unavailable |
+| `survivability_mode.fallback_capacity` | integer | yes | 20 | Tokens in fallback in-memory bucket |
+| `survivability_mode.fallback_refill_rate_per_sec` | number | yes | 5 | Tokens/sec in fallback bucket |
+
+### routes[]
+
+| Field | Type | Required | Default | Description |
+| :---- | :---- | :---- | :---- | :---- |
+| `name` | string | yes | — | Unique route name (used in logs and metrics) |
+| `hostnames` | string[] | yes | — | List of hostnames this route matches (exact match) |
+| `path_prefix` | string | yes | — | Path prefix to match (longest match wins when multiple routes match) |
+| `methods` | string[] | yes | — | Allowed HTTP methods (GET, POST, PUT, DELETE, PATCH, HEAD) |
+| `auth_required` | boolean | yes | false | Whether this route requires JWT authentication |
+| `auth_provider` | string | if auth_required=true | — | Name of auth provider to use |
+| `required_scopes` | string[] | no | — | If present, JWT token must contain all these scopes |
+| `rate_limit.bucket_capacity` | integer | yes | — | Maximum tokens in bucket |
+| `rate_limit.refill_rate_per_sec` | number | yes | — | Tokens refilled per second |
+| `rate_limit.key_by` | string | yes | — | Dimension: `ip` or `sub` (JWT subject) |
+| `upstream.service` | string | yes | — | Name of upstream service (must exist in services[]) |
+| `upstream.request_timeout_ms` | integer | yes | 5000 | Timeout for upstream requests |
+| `upstream.retries` | integer | yes | 1 | Number of retries for idempotent methods |
+
+### services[]
+
+| Field | Type | Required | Default | Description |
+| :---- | :---- | :---- | :---- | :---- |
+| `name` | string | yes | — | Unique service name (referenced by routes) |
+| `endpoints` | string[] | yes | — | List of upstream addresses (host:port) |
+| `health_check.path` | string | yes | — | Health check endpoint (must start with `/`) |
+| `health_check.interval_ms` | integer | yes | 2000 | Interval between health checks (milliseconds) |
+| `health_check.timeout_ms` | integer | yes | 500 | Timeout for each health check |
+
+### observability
+
+| Field | Type | Required | Default | Description |
+| :---- | :---- | :---- | :---- | :---- |
+| `access_log_json` | boolean | yes | true | Format access logs as JSON (vs plain text) |
+| `prometheus_enabled` | boolean | yes | true | Expose /metrics endpoint |
+| `tracing.enabled` | boolean | yes | false | Enable distributed tracing |
+| `tracing.otlp_endpoint` | string | if tracing.enabled | — | OpenTelemetry collector endpoint (http://localhost:4317) |
+| `tracing.sample_rate` | number | if tracing.enabled | 0.0 | Trace sampling rate (0.0-1.0) |
+
+## Validation Rules
+
+The configuration loader must enforce these rules:
+
+1. **Uniqueness**
+   - All route names must be unique
+   - All service names must be unique
+   - All auth provider names must be unique
+
+2. **Referential Integrity**
+   - Every route's `upstream.service` must exist in `services[]`
+   - Every route with `auth_required: true` must have `auth_provider` pointing to an existing provider
+
+3. **Type & Value Constraints**
+   - `bucket_capacity >= 1`
+   - `refill_rate_per_sec > 0`
+   - `path_prefix` must start with `/`
+   - `health_check.path` must start with `/`
+   - `methods` must be valid HTTP methods: GET, POST, PUT, DELETE, PATCH, HEAD
+   - `jwks_uri` must be a valid URL
+   - `redis_address` must be host:port format
+   - `cache_ttl_seconds > 0`
+   - `clock_skew_seconds >= 0`
+   - `tracing.sample_rate` must be 0.0-1.0
+
+4. **Conditional Requirements**
+   - If `auth_required: true`, then `auth_provider` must be specified
+   - If `required_scopes` is present, it must be a non-empty list
+   - If `tracing.enabled: true`, then `otlp_endpoint` must be specified
+
+5. **No Deprecated Fields**
+   - agents must not invent new fields
+   - Gateway must reject config with unknown fields
+
+## Example: Complete Valid Config
+
+```yaml
+version: 1
+
+gateway:
+  listen_address: "0.0.0.0:8080"
+  admin_address: "0.0.0.0:9090"
+  request_timeout_ms: 15000
+  idle_timeout_ms: 60000
+  max_request_body_bytes: 10485760
+  trust_forwarded_headers: false
+
+auth:
+  providers:
+    - name: "main"
+      issuer: "https://auth.example.local/"
+      audience: "api-gateway"
+      jwks_uri: "http://localhost:7001/.well-known/jwks.json"
+      cache_ttl_seconds: 300
+      clock_skew_seconds: 30
+
+rate_limits:
+  redis_address: "redis:6379"
+  redis_db: 0
+  redis_key_prefix: "rl"
+  default_timeout_ms: 50
+  fail_open: false
+  survivability_mode:
+    enabled: true
+    fallback_capacity: 20
+    fallback_refill_rate_per_sec: 5
+
+routes:
+  - name: "public-api"
+    hostnames: ["api.example.com"]
+    path_prefix: "/public"
+    methods: ["GET", "POST"]
+    auth_required: false
+    rate_limit:
+      bucket_capacity: 100
+      refill_rate_per_sec: 10
+      key_by: "ip"
+    upstream:
+      service: "backend"
+      request_timeout_ms: 5000
+      retries: 1
+
+  - name: "protected-api"
+    hostnames: ["api.example.com"]
+    path_prefix: "/protected"
+    methods: ["GET", "POST"]
+    auth_required: true
+    auth_provider: "main"
+    required_scopes: ["api.read"]
+    rate_limit:
+      bucket_capacity: 50
+      refill_rate_per_sec: 5
+      key_by: "sub"
+    upstream:
+      service: "backend"
+      request_timeout_ms: 5000
+      retries: 1
+
+services:
+  - name: "backend"
+    endpoints:
+      - "backend-01:8080"
+      - "backend-02:8080"
+    health_check:
+      path: "/healthz"
+      interval_ms: 2000
+      timeout_ms: 500
+
+observability:
+  access_log_json: true
+  prometheus_enabled: true
+  tracing:
+    enabled: false
+    otlp_endpoint: ""
+    sample_rate: 0.0
+```
+
+## Further Reading
+
+- [auth.md](auth.md) — Detailed JWT validation rules
+- [rate-limiting.md](rate-limiting.md) — Detailed rate limiter behavior
+- [observability.md](observability.md) — Metrics and logging schemas

--- a/specs/observability.md
+++ b/specs/observability.md
@@ -1,0 +1,356 @@
+# Observability Specification
+
+This document specifies the metrics, logging, and tracing contracts for the API Gateway v1.
+
+## Three Pillars: Logs, Metrics, Traces
+
+### Access Logs (JSON)
+
+- **What:** Every request, structured JSON to stdout
+- **When:** After response is fully streamed to client
+- **Cardinality:** One line per request (unbounded volume, bounded cardinality)
+
+### Prometheus Metrics
+
+- **What:** Counters, histograms for request patterns
+- **When:** Scraped on-demand (every 15-30 seconds typical)
+- **Cardinality:** Strictly bounded (no raw paths, user IDs)
+
+### Distributed Traces (Optional)
+
+- **What:** Request flow across services
+- **When:** Sampled requests sent to OpenTelemetry collector
+- **Cardinality:** Sampled at configured rate (0-100%)
+
+---
+
+## Access Logs
+
+### Schema
+
+Every request produces exactly one JSON line on stdout:
+
+```json
+{
+  "ts":"2026-03-29T23:59:59.000Z",
+  "request_id":"2c3c7b8f",
+  "remote_addr":"172.18.0.1",
+  "host":"localhost",
+  "method":"GET",
+  "path":"/private/data",
+  "route":"private-echo",
+  "status":200,
+  "duration_ms":14,
+  "bytes_in":123,
+  "bytes_out":456,
+  "auth_subject":"user-123",
+  "rate_limit_mode":"redis",
+  "upstream_service":"echo-private",
+  "upstream_addr":"echo-backend:8081"
+}
+```
+
+### Field Reference
+
+| Field | Type | Required | Description |
+| :---- | :---- | :---- | :---- |
+| `ts` | string (RFC3339) | yes | Request timestamp (UTC, millisecond precision) |
+| `request_id` | string | yes | Unique request ID (short hash or UUID) |
+| `remote_addr` | string | yes | Client IP address |
+| `host` | string | yes | HTTP `Host` header value |
+| `method` | string | yes | HTTP method (GET, POST, etc.) |
+| `path` | string | yes | Request path (e.g., `/private/data`) |
+| `route` | string | yes | Matched route name from config (e.g., `private-echo`) |
+| `status` | integer | yes | HTTP status code (200, 401, 429, 503, etc.) |
+| `duration_ms` | integer | yes | Total time from request in to response complete (milliseconds) |
+| `bytes_in` | integer | yes | Request body size (0 if no body) |
+| `bytes_out` | integer | yes | Response body size |
+| `auth_subject` | string or null | yes | JWT `sub` claim if authenticated; `null` if unauth |
+| `rate_limit_mode` | string | yes | `redis` or `degraded-local` or `none` |
+| `upstream_service` | string | yes | Name of upstream service from config |
+| `upstream_addr` | string | yes | Actual upstream address used (e.g., `host:port`) |
+
+### Constraints
+
+- **No raw paths in labels** — All requests use the matched route name
+- **No user identifiers in separate fields** — Only the JWT `sub` (if authenticated)
+- **No PII** — Do not log query parameters, headers, or request bodies
+
+### Unmatched (404) Requests
+
+If no route matches:
+
+```json
+{
+  "ts":"2026-03-29T23:59:59.000Z",
+  "request_id":"2c3c7b8f",
+  "remote_addr":"172.18.0.1",
+  "host":"localhost",
+  "method":"GET",
+  "path":"/nonexistent",
+  "route":"",
+  "status":404,
+  "duration_ms":1,
+  "bytes_in":0,
+  "bytes_out":14,
+  "auth_subject":null,
+  "rate_limit_mode":"none",
+  "upstream_service":"",
+  "upstream_addr":""
+}
+```
+
+---
+
+## Prometheus Metrics
+
+All metrics are tagged with safe, bounded label cardinality.
+
+### Counter Metrics
+
+#### `gateway_http_requests_total`
+
+Total HTTP requests processed.
+
+```
+gateway_http_requests_total{route="private-api", method="GET", status_class="200"} 1250
+gateway_http_requests_total{route="public-api", method="POST", status_class="400"} 3
+gateway_http_requests_total{route="", method="GET", status_class="404"} 15
+```
+
+Labels:
+- `route` (string) — Route name, or empty string if 404
+- `method` (string) — HTTP method (GET, POST, etc.)
+- `status_class` (string) — Status code bucket (1xx, 2xx, 3xx, 4xx, 5xx)
+
+#### `gateway_http_request_duration_ms`
+
+Request duration in milliseconds (histogram).
+
+```
+gateway_http_request_duration_ms_bucket{route="private-api",le="10"} 120
+gateway_http_request_duration_ms_bucket{route="private-api",le="50"} 245
+gateway_http_request_duration_ms_bucket{route="private-api",le="100"} 289
+gateway_http_request_duration_ms_bucket{route="private-api",le="+Inf"} 300
+gateway_http_request_duration_ms_sum{route="private-api"} 8900
+gateway_http_request_duration_ms_count{route="private-api"} 300
+```
+
+Labels:
+- `route` (string) — Route name
+
+#### `gateway_auth_failures_total`
+
+Authentication failures.
+
+```
+gateway_auth_failures_total{route="private-api", reason="invalid_signature"} 2
+gateway_auth_failures_total{route="private-api", reason="token_expired"} 5
+gateway_auth_failures_total{route="private-api", reason="missing_token"} 8
+```
+
+Labels:
+- `route` (string) — Route name
+- `reason` (string) — `invalid_signature`, `token_expired`, `missing_token`, `insufficient_scopes`, etc.
+
+#### `gateway_rate_limit_allowed_total`
+
+Requests allowed by rate limiter.
+
+```
+gateway_rate_limit_allowed_total{route="private-api"} 950
+gateway_rate_limit_allowed_total{route="public-api"} 5000
+```
+
+Labels:
+- `route` (string) — Route name
+
+#### `gateway_rate_limit_denied_total`
+
+Requests denied by rate limiter.
+
+```
+gateway_rate_limit_denied_total{route="private-api"} 50
+gateway_rate_limit_denied_total{route="public-api"} 100
+```
+
+Labels:
+- `route` (string) — Route name
+
+#### `gateway_rate_limit_degraded_total`
+
+Rate limiting requests served from degraded in-memory fallback.
+
+```
+gateway_rate_limit_degraded_total{route="private-api"} 120
+```
+
+Labels:
+- `route` (string) — Route name
+
+#### `gateway_upstream_failures_total`
+
+Upstream service failures (connection errors, timeouts, 5xx responses).
+
+```
+gateway_upstream_failures_total{route="private-api", service="backend", reason="connection_timeout"} 3
+gateway_upstream_failures_total{route="private-api", service="backend", reason="upstream_5xx"} 1
+```
+
+Labels:
+- `route` (string) — Route name
+- `service` (string) — Upstream service name
+- `reason` (string) — `connection_timeout`, `read_timeout`, `upstream_5xx`, etc.
+
+#### `gateway_config_reload_total`
+
+Configuration reload attempts.
+
+```
+gateway_config_reload_total{result="success"} 5
+gateway_config_reload_total{result="validation_error"} 1
+```
+
+Labels:
+- `result` (string) — `success` or `validation_error`
+
+### Gauge Metrics
+
+#### `gateway_inflight_requests`
+
+Current in-flight HTTP requests.
+
+```
+gateway_inflight_requests 42
+```
+
+No labels.
+
+### Histogram Metrics
+
+For histograms, Prometheus automatically creates `_bucket`, `_sum`, and `_count` series. No additional setup required.
+
+---
+
+## Label Cardinality Rules
+
+**Allowed dynamic labels:**
+- `route` — Safe because routes are defined in config (finite)
+- `method` — Safe (fixed HTTP methods)
+- `status_class` — Safe (5 classes: 1xx-5xx)
+- `service` — Safe (services are defined in config)
+- `reason` — Safe (bounded set of defined failure reasons)
+
+**Forbidden labels:**
+- ~~Raw request path~~ — Would explode cardinality
+- ~~User ID~~ — Would explode cardinality
+- ~~JWT `sub` claim~~ — Would explode cardinality
+- ~~IP address~~ — Would explode cardinality
+
+---
+
+## Distributed Tracing (Optional)
+
+If `observability.tracing.enabled: true`:
+
+### Trace Propagation
+
+Every request:
+
+1. Generate or extract `trace_id` from `traceparent` header (W3C Trace Context)
+2. Create a root span for the gateway request
+3. Inject `traceparent` header into upstream request
+4. Inject `x-request-id` header (same value as trace_id or separate)
+
+### Sample Rate
+
+- **`tracing.sample_rate: 0.0`** — No sampling (0%)
+- **`tracing.sample_rate: 1.0`** — 100% sampling (all requests)
+- **`tracing.sample_rate: 0.01`** — 1% sampling
+
+### Span Attributes
+
+Each gateway span should include:
+
+```
+trace_id: "2c3c7b8f-....."
+span_id: "a1b2c3d4"
+parent_span_id: (if not root)
+
+attributes:
+  http.method: "GET"
+  http.url: "/private/data"
+  http.status_code: 200
+  http.request_content_length: 123
+  http.response_content_length: 456
+  route: "private-api"
+  upstream_service: "backend"
+  upstream_addr: "backend-01:8080"
+  auth_subject: "user-123"  (if authenticated)
+  duration_ms: 14
+
+events:
+  - name: "auth_check", timestamp: t1
+  - name: "rate_limit_check", timestamp: t2
+  - name: "upstream_request_start", timestamp: t3
+  - name: "upstream_response_received", timestamp: t4
+```
+
+### Collector Configuration
+
+If tracing is enabled, the gateway connects to an OpenTelemetry collector:
+
+```yaml
+observability:
+  tracing:
+    enabled: true
+    otlp_endpoint: "http://otel-collector:4317"  # gRPC endpoint
+    sample_rate: 0.05  # 5%
+```
+
+---
+
+## Metrics Endpoint
+
+The gateway exposes Prometheus metrics at:
+
+```
+GET http://localhost:9090/metrics
+```
+
+(Admin address, not gateway address)
+
+Response format is Prometheus text exposition format (standard).
+
+---
+
+## Observability Best Practices
+
+1. **Avoid Fires:** Do not emit unbounded-cardinality metrics (e.g., per-path metrics)
+2. **Be Complete:** Every important event (auth failure, rate limit, etc.) has a metric
+3. **Be Observable:** Metrics, logs, and traces should correlate via `request_id`
+4. **Sample Wisely:** Tracing at high sample rates is expensive; use 1-5% for production
+5. **Alert on Patterns:** Alert on metric trends, not just raw counts
+
+---
+
+## Testing Checklist
+
+- [ ] Every request produces exactly one JSON access log line
+- [ ] All required fields in access log are populated
+- [ ] Prometheus metrics are exposed at /metrics (admin port)
+- [ ] Metrics have bounded cardinality (no path explosion)
+- [ ] `route` label is always from config (never raw path)
+- [ ] Auth failures increment `gateway_auth_failures_total`
+- [ ] Rate limit denials increment `gateway_rate_limit_denied_total`
+- [ ] Upstream failures increment `gateway_upstream_failures_total`
+- [ ] Tracing (if enabled) exports spans to OTLP collector
+- [ ] `request_id` is injected into all requests and logs
+- [ ] `traceparent` header is passed through to upstream services
+
+## Further Reading
+
+- [base-case-implementation-spec.md](base-case-implementation-spec.md) — Observability section
+- [config-schema.md](config-schema.md) — Observability config
+- [auth.md](auth.md) — Auth failure reasons
+- [rate-limiting.md](rate-limiting.md) — Rate limit metrics

--- a/specs/rate-limiting.md
+++ b/specs/rate-limiting.md
@@ -1,0 +1,218 @@
+# Rate Limiting Specification
+
+This document specifies the exact rate-limiting contract for the API Gateway v1. The implementation uses a Token Bucket algorithm with Redis + Lua for atomicity and a local in-memory fallback for survivability.
+
+## Algorithm: Token Bucket
+
+The gateway uses the Token Bucket algorithm for rate limiting:
+
+- **Tokens** are issued at a constant `refill_rate_per_sec`
+- **Capacity** is fixed at `bucket_capacity`
+- A request is **allowed** if it can deduct `1` token from the bucket
+- A request is **denied** if insufficient tokens remain
+- **Tokens accumulate** up to the capacity
+- **Idle buckets** expire from Redis after period of inactivity
+
+### Why Token Bucket?
+
+- Accommodates bursty real-world traffic (REST, WebSocket)
+- Memory efficient (2 values per bucket: tokens + last_refill_timestamp)
+- Permits controlled bursts up to capacity
+- Easy to tune per route
+
+## Redis-Based Token Bucket (Primary)
+
+### Redis Key Format
+
+```
+rl:{route_name}:{dimension}:{dimension_value}
+```
+
+Examples:
+
+- `rl:public-api:ip:192.168.1.20` — Rate limit for a route by IP
+- `rl:private-api:sub:user-123` — Rate limit for a route by JWT subject
+
+### Redis Hash Fields
+
+Each bucket is stored as a Redis Hash with these fields:
+
+| Field | Type | Description |
+| :---- | :---- | :---- |
+| `tokens` | float | Current token count in bucket |
+| `last_refill_ms` | integer | Last refill timestamp (milliseconds since epoch) |
+
+### Lua Script Execution
+
+The token bucket logic is encapsulated in a Redis Lua script to ensure atomic execution (no race conditions). This script runs once per request on the Redis server.
+
+**Script Input (ARGV):**
+
+```
+ARGV[1] = now_ms                (current time in milliseconds)
+ARGV[2] = capacity              (bucket capacity)
+ARGV[3] = refill_rate_per_sec   (float)
+ARGV[4] = requested_tokens      (typically 1)
+ARGV[5] = ttl_seconds           (key expiration time)
+```
+
+**Script Output:**
+
+```json
+{
+  "allowed": 1,
+  "remaining_tokens": 12,
+  "retry_after_ms": 0
+}
+```
+
+or (if denied):
+
+```json
+{
+  "allowed": 0,
+  "remaining_tokens": 0,
+  "retry_after_ms": 180
+}
+```
+
+### Lua Script Logic
+
+Pseudocode:
+
+```
+1. Retrieve current tokens and last_refill_ms from hash (or defaults: tokens=capacity, last_refill_ms=now_ms)
+2. Elapsed_seconds = (now_ms - last_refill_ms) / 1000.0
+3. Refilled_tokens = refill_rate_per_sec * elapsed_seconds
+4. New_tokens = min(tokens + refilled_tokens, capacity)
+5. If new_tokens >= requested_tokens:
+     a. new_tokens -= requested_tokens
+     b. Set hash fields: tokens = new_tokens, last_refill_ms = now_ms
+     c. Set key TTL = ttl_seconds
+     d. Return {allowed: 1, remaining_tokens: new_tokens, retry_after_ms: 0}
+6. Else:
+     a. Do NOT modify hash
+     b. Calculate retry_after_ms based on time to next token refill
+     c. Return {allowed: 0, remaining_tokens: 0, retry_after_ms: retry_after_ms}
+```
+
+### TTL Calculation
+
+Idle rate-limit buckets should expire from Redis to conserve memory:
+
+```
+ttl_seconds = ceil((capacity / refill_rate_per_sec) * 2)
+```
+
+Example: Capacity=50, refill_rate=10/sec → TTL = ceil((50/10)*2) = 10 seconds.
+
+This gives a 2× buffer so that completely empty buckets (rare) don't expire immediately.
+
+## Rate-Limit Dimensions
+
+A route's rate-limit is keyed by one of these dimensions:
+
+| Dimension | Key | Example |
+| :---- | :---- | :---- |
+| `ip` | Client IP address | `rl:api:ip:192.168.1.20` |
+| `sub` | JWT subject claim | `rl:api:sub:user-123` |
+
+For unprotected routes (no auth required), use `key_by: ip`.
+For protected routes, use `key_by: sub` to rate-limit per authenticated user.
+
+## Redis Unavailable (Graceful Degradation)
+
+If Redis is unreachable (timeout, connection error, etc.):
+
+1. **If `survivability_mode.enabled: true`:**
+   - Fall back to a **local in-memory token bucket** for the same request
+   - Use the configuration's `survivability_mode.fallback_capacity` and `survivability_mode.fallback_refill_rate_per_sec`
+   - Emit response header: `x-rate-limit-mode: degraded-local`
+   - Increment metric: `gateway_rate_limit_degraded_total{route}`
+
+2. **If `survivability_mode.enabled: false` and `fail_open: true`:**
+   - Allow the request (no rate-limiting)
+   - Emit warning log
+
+3. **If `survivability_mode.enabled: false` and `fail_open: false`:**
+   - Reject the request with 503 Service Unavailable
+   - Body: `{"error":"rate_limiter_unavailable"}`
+
+### Degraded Mode Semantics
+
+In degraded mode, each gateway instance maintains its own independent in-memory token bucket. This means:
+
+- **No global fairness:** Multiple gateway replicas do not share token state
+- **Per-instance limits:** Each replica independently enforces its fallback capacity
+- **Temporary override:** Rate limits become per-replica instead of global
+- **Expected behavior:** If Redis partition heals, rate limit enforcement resumes at the global level
+
+**This is intentional:** Degraded mode prioritizes availability over strict fairness.
+
+## Per-Route Configuration
+
+In `configs/gateway.yaml`:
+
+```yaml
+routes:
+  - name: "api"
+    rate_limit:
+      bucket_capacity: 50
+      refill_rate_per_sec: 10
+      key_by: "ip"
+```
+
+All routes with `rate_limit` policy are subject to limiting.
+
+## Response Headers
+
+On each request, the gateway may emit rate-limit headers:
+
+```
+x-rate-limit-limit: 50              (bucket capacity)
+x-rate-limit-remaining: 12          (tokens left after this request)
+x-rate-limit-reset: 1760000000      (Unix timestamp when next token refills)
+x-rate-limit-mode: redis            (or "degraded-local")
+retry-after: 180                    (only if denied: seconds to wait)
+```
+
+## Status Codes
+
+| Condition | Status | Body |
+| :---- | :---- | :---- |
+| Request allowed | 200-399 | (normal upstream response) |
+| Rate limit exceeded | 429 | `{"error":"rate_limit_exceeded"}` |
+| Rate limiter unavailable (fail_open=false) | 503 | `{"error":"rate_limiter_unavailable"}` |
+
+## Error Scenarios
+
+| Scenario | Behavior |
+| :---- | :---- |
+| Route has no `rate_limit` policy | No rate limiting applied; request proceeds normally |
+| Redis timeout (default 50ms) | Trigger degraded mode or fail based on config |
+| Key doesn't exist in Redis | Initialize new bucket with full capacity |
+| Concurrent requests race condition | Lua atomicity prevents this; no race possible |
+| Dimension value is empty (e.g., unknown IP) | Use empty string as dimension value (e.g., `rl:api:ip:`) |
+
+## Testing Checklist
+
+- [ ] Requests within bucket capacity are allowed
+- [ ] Requests exceeding capacity are denied with 429
+- [ ] Tokens refill at the configured rate
+- [ ] Bucket capacity is respected as a hard ceiling
+- [ ] TTL-based expiration cleans up idle buckets from Redis
+- [ ] Unknown `kid` in JWT causes fallback to degraded local bucket (if enabled)
+- [ ] `retry-after` header accurately estimates time until next token available
+- [ ] Headers `x-rate-limit-*` are present on every request
+- [ ] Degraded mode does NOT synchronize state across replicas
+- [ ] Switching from degraded back to Redis is seamless
+- [ ] `key_by: ip` correctly extracts client IP
+- [ ] `key_by: sub` correctly uses JWT subject claim
+- [ ] Empty dimension values are handled gracefully
+
+## Further Reading
+
+- [config-schema.md](config-schema.md) — Rate limit configuration
+- [auth.md](auth.md) — JWT subject claim for `key_by: sub`
+- [observability.md](observability.md) — Rate limit metrics
+- [base-case-implementation-spec.md](base-case-implementation-spec.md) — Failure modes


### PR DESCRIPTION
## Summary

- Architecture design doc and v1 implementation decisions
- 6 specification documents covering config schema, auth, rate limiting, observability, admin API, and base case
- Single-node Docker Compose example with sample gateway config
- Deployment manifests (Docker Compose, Prometheus)
- Dev helper scripts (JWT generation, smoke tests)
- Updated .gitignore to exclude docs/research/*.md from public repo

## Linked Issue

- Closes https://github.com/shikarii/OpenApiGateway/issues/1 (partial -- adds specs that define acceptance criteria)

## Base Branch

- [x] This PR targets `develop`

## Validation

- [x] No sensitive content in any committed file
- [x] `docs/research/*.md` excluded via .gitignore
- [x] All specs use placeholder values only

## Risks and Tradeoffs

None. Documentation-only PR.