### PR TITLE
feat: admin API endpoints (healthz, readyz, config)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,8 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -83,10 +85,15 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -107,6 +114,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -120,6 +128,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bytes"
@@ -137,16 +154,38 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 name = "controlplane"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "prost",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "shared",
  "tokio",
  "tonic",
+ "tower 0.5.3",
  "tracing",
  "tracing-subscriber",
  "url",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -158,6 +197,16 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -245,6 +294,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -851,6 +910,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +943,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1109,8 +1202,10 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper",
+ "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1131,6 +1226,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1193,6 +1289,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,6 +1329,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ prost = "0.13"
 thiserror = "2"
 serde_yaml = "0.9"
 url = "2"
+axum = "0.7"
+sha2 = "0.10"
+tower = { version = "0.5", features = ["util"] }

--- a/controlplane/Cargo.toml
+++ b/controlplane/Cargo.toml
@@ -15,3 +15,8 @@ tonic = { workspace = true }
 prost = { workspace = true }
 serde_yaml = { workspace = true }
 url = { workspace = true }
+axum = { workspace = true }
+sha2 = { workspace = true }
+
+[dev-dependencies]
+tower = { workspace = true }

--- a/controlplane/src/admin/handlers.rs
+++ b/controlplane/src/admin/handlers.rs
@@ -1,0 +1,249 @@
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+
+use super::responses::{
+    ConfigStatusResponse, HealthResponse, ReadyResponse, ReloadErrorResponse, ReloadSuccessResponse,
+};
+use super::state::{now_unix, sha256_hex, ReloadResult, SharedState};
+use crate::config;
+
+/// `GET /healthz` -- liveness probe. Always returns 200.
+pub(crate) async fn healthz() -> Json<HealthResponse> {
+    Json(HealthResponse { ok: true })
+}
+
+/// `GET /readyz` -- readiness probe. Returns 200 if config is loaded.
+pub(crate) async fn readyz(State(state): State<SharedState>) -> impl IntoResponse {
+    let cs = state.config_state.read().await;
+
+    // Config is always loaded after startup (we exit on failure).
+    // Redis and JWKS checks are stubbed until those subsystems exist.
+    let response = ReadyResponse {
+        ok: true,
+        config_loaded: true,
+        redis_ok: true, // TODO(#12): real Redis check
+        jwks_ok: true,  // TODO(#11): real JWKS check
+        last_config_reload_unix: cs.last_reload_unix,
+    };
+
+    (StatusCode::OK, Json(response))
+}
+
+/// `GET /config/status` -- current config metadata.
+pub(crate) async fn config_status(State(state): State<SharedState>) -> Json<ConfigStatusResponse> {
+    let cs = state.config_state.read().await;
+
+    Json(ConfigStatusResponse {
+        active_config_version: cs.config.version,
+        active_config_sha256: cs.sha256.clone(),
+        last_reload_result: cs.last_reload_result.as_str().to_owned(),
+        last_reload_error: cs.last_reload_error.clone(),
+        last_reload_unix: cs.last_reload_unix,
+    })
+}
+
+/// `POST /config/reload` -- reload config from disk.
+pub(crate) async fn config_reload(State(state): State<SharedState>) -> impl IntoResponse {
+    let now = now_unix();
+
+    // Read raw bytes from disk.
+    let raw = match std::fs::read(&state.config_path) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            let mut cs = state.config_state.write().await;
+            let error_msg = format!("failed to read {}: {e}", state.config_path.display());
+            cs.last_reload_unix = now;
+            cs.last_reload_result = ReloadResult::ValidationError;
+            cs.last_reload_error = Some(error_msg.clone());
+
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(
+                    serde_json::to_value(ReloadErrorResponse {
+                        ok: false,
+                        message: "config validation failed".into(),
+                        error: error_msg,
+                        reload_timestamp: now,
+                    })
+                    .expect("serialization cannot fail"),
+                ),
+            );
+        }
+    };
+
+    let yaml = String::from_utf8_lossy(&raw);
+
+    // Parse and validate.
+    match config::load_config_from_str(&yaml) {
+        Ok(new_config) => {
+            let new_sha = sha256_hex(&raw);
+            let mut cs = state.config_state.write().await;
+            let previous_sha = cs.sha256.clone();
+
+            cs.config = new_config;
+            cs.sha256 = new_sha.clone();
+            cs.last_reload_unix = now;
+            cs.last_reload_result = ReloadResult::Success;
+            cs.last_reload_error = None;
+
+            tracing::info!(
+                previous_sha256 = %previous_sha,
+                new_sha256 = %new_sha,
+                "config reloaded"
+            );
+
+            (
+                StatusCode::OK,
+                Json(
+                    serde_json::to_value(ReloadSuccessResponse {
+                        ok: true,
+                        message: "config reloaded successfully".into(),
+                        previous_sha256: previous_sha,
+                        new_sha256: new_sha,
+                        reload_timestamp: now,
+                    })
+                    .expect("serialization cannot fail"),
+                ),
+            )
+        }
+        Err(errs) => {
+            let error_msg = errs.to_string();
+            let mut cs = state.config_state.write().await;
+            cs.last_reload_unix = now;
+            cs.last_reload_result = ReloadResult::ValidationError;
+            cs.last_reload_error = Some(error_msg.clone());
+
+            tracing::warn!(%errs, "config reload validation failed");
+
+            (
+                StatusCode::BAD_REQUEST,
+                Json(
+                    serde_json::to_value(ReloadErrorResponse {
+                        ok: false,
+                        message: "config validation failed".into(),
+                        error: error_msg,
+                        reload_timestamp: now,
+                    })
+                    .expect("serialization cannot fail"),
+                ),
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use axum::body::Body;
+    use axum::http::{Method, Request};
+    use axum::Router;
+    use tower::ServiceExt;
+
+    use super::super::state::build_state;
+    use super::*;
+
+    fn test_router() -> Router {
+        let yaml = include_str!("../../../examples/configs/gateway-single-node.yaml");
+        let cfg = config::load_config_from_str(yaml).unwrap();
+        let state = build_state(cfg, yaml.as_bytes(), PathBuf::from("nonexistent.yaml"));
+
+        Router::new()
+            .route("/healthz", axum::routing::get(healthz))
+            .route("/readyz", axum::routing::get(readyz))
+            .route("/config/status", axum::routing::get(config_status))
+            .route("/config/reload", axum::routing::post(config_reload))
+            .with_state(state)
+    }
+
+    #[tokio::test]
+    async fn healthz_returns_200() {
+        let app = test_router();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["ok"], true);
+    }
+
+    #[tokio::test]
+    async fn readyz_returns_200() {
+        let app = test_router();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/readyz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["ok"], true);
+        assert_eq!(json["config_loaded"], true);
+    }
+
+    #[tokio::test]
+    async fn config_status_returns_version_and_hash() {
+        let app = test_router();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/config/status")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["active_config_version"], 1);
+        assert!(json["active_config_sha256"].as_str().unwrap().len() == 64);
+        assert_eq!(json["last_reload_result"], "success");
+        assert!(json["last_reload_error"].is_null());
+    }
+
+    #[tokio::test]
+    async fn config_reload_returns_400_when_file_missing() {
+        let app = test_router();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/config/reload")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["ok"], false);
+    }
+}

--- a/controlplane/src/admin/mod.rs
+++ b/controlplane/src/admin/mod.rs
@@ -1,0 +1,23 @@
+mod handlers;
+pub(crate) mod responses;
+pub(crate) mod state;
+
+use axum::Router;
+
+use self::state::SharedState;
+
+/// Build the admin API router with all endpoints.
+pub(crate) fn router(state: SharedState) -> Router {
+    Router::new()
+        .route("/healthz", axum::routing::get(handlers::healthz))
+        .route("/readyz", axum::routing::get(handlers::readyz))
+        .route(
+            "/config/status",
+            axum::routing::get(handlers::config_status),
+        )
+        .route(
+            "/config/reload",
+            axum::routing::post(handlers::config_reload),
+        )
+        .with_state(state)
+}

--- a/controlplane/src/admin/responses.rs
+++ b/controlplane/src/admin/responses.rs
@@ -1,0 +1,46 @@
+use serde::Serialize;
+
+/// Response for `GET /healthz`.
+#[derive(Debug, Serialize)]
+pub(crate) struct HealthResponse {
+    pub ok: bool,
+}
+
+/// Response for `GET /readyz`.
+#[derive(Debug, Serialize)]
+pub(crate) struct ReadyResponse {
+    pub ok: bool,
+    pub config_loaded: bool,
+    pub redis_ok: bool,
+    pub jwks_ok: bool,
+    pub last_config_reload_unix: i64,
+}
+
+/// Response for `GET /config/status`.
+#[derive(Debug, Serialize)]
+pub(crate) struct ConfigStatusResponse {
+    pub active_config_version: u32,
+    pub active_config_sha256: String,
+    pub last_reload_result: String,
+    pub last_reload_error: Option<String>,
+    pub last_reload_unix: i64,
+}
+
+/// Success response for `POST /config/reload`.
+#[derive(Debug, Serialize)]
+pub(crate) struct ReloadSuccessResponse {
+    pub ok: bool,
+    pub message: String,
+    pub previous_sha256: String,
+    pub new_sha256: String,
+    pub reload_timestamp: i64,
+}
+
+/// Error response for `POST /config/reload`.
+#[derive(Debug, Serialize)]
+pub(crate) struct ReloadErrorResponse {
+    pub ok: bool,
+    pub message: String,
+    pub error: String,
+    pub reload_timestamp: i64,
+}

--- a/controlplane/src/admin/state.rs
+++ b/controlplane/src/admin/state.rs
@@ -1,0 +1,96 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use sha2::{Digest, Sha256};
+use shared::config_types::GatewayConfig;
+use tokio::sync::RwLock;
+
+/// Shared application state for the admin API.
+pub(crate) type SharedState = Arc<AppState>;
+
+/// Top-level state container.
+pub(crate) struct AppState {
+    pub config_state: RwLock<ConfigState>,
+    pub config_path: PathBuf,
+}
+
+/// Mutable config state protected by a `RwLock`.
+pub(crate) struct ConfigState {
+    pub config: GatewayConfig,
+    pub sha256: String,
+    pub last_reload_unix: i64,
+    pub last_reload_result: ReloadResult,
+    pub last_reload_error: Option<String>,
+}
+
+/// Result of the last config reload attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReloadResult {
+    Success,
+    ValidationError,
+}
+
+impl ReloadResult {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::ValidationError => "validation_error",
+        }
+    }
+}
+
+/// Compute SHA256 hex digest for raw config bytes.
+pub(crate) fn sha256_hex(data: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    format!("{:x}", hasher.finalize())
+}
+
+/// Current Unix timestamp in seconds.
+pub(crate) fn now_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+/// Build initial [`AppState`] from a loaded config and its raw YAML bytes.
+pub(crate) fn build_state(
+    config: GatewayConfig,
+    raw_yaml: &[u8],
+    config_path: PathBuf,
+) -> SharedState {
+    let sha256 = sha256_hex(raw_yaml);
+    let now = now_unix();
+
+    Arc::new(AppState {
+        config_state: RwLock::new(ConfigState {
+            config,
+            sha256,
+            last_reload_unix: now,
+            last_reload_result: ReloadResult::Success,
+            last_reload_error: None,
+        }),
+        config_path,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_deterministic() {
+        let hash = sha256_hex(b"hello world");
+        assert_eq!(
+            hash,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+    }
+
+    #[test]
+    fn now_unix_positive() {
+        assert!(now_unix() > 0);
+    }
+}

--- a/controlplane/src/config/loader.rs
+++ b/controlplane/src/config/loader.rs
@@ -6,6 +6,7 @@ use shared::config_types::GatewayConfig;
 use super::validation;
 
 /// Load and validate a gateway config from a YAML file.
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn load_config(path: &Path) -> Result<GatewayConfig, ConfigErrors> {
     let contents = std::fs::read_to_string(path).map_err(|e| {
         ConfigErrors::new(vec![ConfigError::YamlParse(format!(

--- a/controlplane/src/config/mod.rs
+++ b/controlplane/src/config/mod.rs
@@ -1,4 +1,4 @@
 mod loader;
 mod validation;
 
-pub(crate) use loader::load_config;
+pub(crate) use loader::load_config_from_str;

--- a/controlplane/src/main.rs
+++ b/controlplane/src/main.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
 
+use tokio::net::TcpListener;
 use tracing_subscriber::EnvFilter;
 
+mod admin;
 mod config;
 
 #[tokio::main]
@@ -16,18 +18,41 @@ async fn main() {
         .map(PathBuf::from)
         .unwrap_or_else(|_| PathBuf::from("configs/gateway.yaml"));
 
-    match config::load_config(&config_path) {
-        Ok(cfg) => {
-            tracing::info!(
-                version = cfg.version,
-                routes = cfg.routes.len(),
-                services = cfg.services.len(),
-                "config loaded"
-            );
+    let raw_yaml = match std::fs::read(&config_path) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            tracing::error!("failed to read {}: {e}", config_path.display());
+            std::process::exit(1);
         }
+    };
+
+    let cfg = match config::load_config_from_str(&String::from_utf8_lossy(&raw_yaml)) {
+        Ok(c) => c,
         Err(errs) => {
             tracing::error!(%errs, "config validation failed");
             std::process::exit(1);
         }
-    }
+    };
+
+    let admin_addr = cfg.gateway.admin_address.clone();
+    tracing::info!(
+        version = cfg.version,
+        routes = cfg.routes.len(),
+        services = cfg.services.len(),
+        "config loaded"
+    );
+
+    let state = admin::state::build_state(cfg, &raw_yaml, config_path);
+    let app = admin::router(state);
+
+    let listener = TcpListener::bind(&admin_addr).await.unwrap_or_else(|e| {
+        tracing::error!(%admin_addr, "failed to bind admin API: {e}");
+        std::process::exit(1);
+    });
+
+    tracing::info!(%admin_addr, "admin API listening");
+    axum::serve(listener, app).await.unwrap_or_else(|e| {
+        tracing::error!("admin API server error: {e}");
+        std::process::exit(1);
+    });
 }


### PR DESCRIPTION
## Summary

- Add Admin API server on separate port (default `:9090`) with four endpoints per spec
- `GET /healthz` -- liveness probe, instant 200
- `GET /readyz` -- readiness probe with config/Redis/JWKS status (Redis and JWKS stubbed until #11/#12)
- `GET /config/status` -- active config version, SHA256 hash, last reload result
- `POST /config/reload` -- validate-then-swap with atomic state update, returns old/new SHA256
- Thread-safe state via `Arc<RwLock<ConfigState>>` for concurrent handler access

Closes https://github.com/shikarii/OpenApiGateway/issues/10

## Changes

| File | LOC | Purpose |
|------|-----|---------|
| `controlplane/src/admin/handlers.rs` | 247 | All 4 endpoint handlers + 4 tests |
| `controlplane/src/admin/state.rs` | 93 | AppState, ConfigState, SHA256 helper, state builder |
| `controlplane/src/admin/responses.rs` | 47 | 5 JSON response structs |
| `controlplane/src/admin/mod.rs` | 20 | Router construction |
| `controlplane/src/main.rs` | 54 | Refactored to build AppState and spawn admin server |

## Base Branch

- [x] This PR targets `develop`

## Validation

- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passed
- [x] `cargo test --workspace` passed (35 tests, 0 failures)
- [x] `bash tools/check-loc.sh` passed (all files within LOC limits)

## Risks and Tradeoffs

- `/readyz` stubs `redis_ok` and `jwks_ok` as `true`; becomes real when #11 and #12 land
- `POST /config/reload` uses blocking `std::fs::read` inside async handler; acceptable for admin API (infrequent, operator-triggered)
- `serde_json::to_value().expect()` used in reload handler for response serialization; these structs are known-serializable so panic is unreachable

## Adversarial Review

- Tested missing config file on reload (returns 400 with descriptive error)
- Verified SHA256 hash is exactly 64 hex characters
- Tested all endpoints return well-formed JSON
- State remains consistent after failed reload (old config preserved)
