### PR TITLE
feat: token bucket rate limiter (Redis + Lua + fallback)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,12 +182,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "controlplane"
 version = "0.1.0"
 dependencies = [
  "axum",
  "jsonwebtoken",
  "prost",
+ "redis",
  "reqwest",
  "serde",
  "serde_json",
@@ -331,6 +355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -665,6 +690,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -952,7 +986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1085,6 +1119,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redis"
+version = "0.27.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "combine",
+ "futures-util",
+ "itertools 0.13.0",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "tokio",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -1302,6 +1359,12 @@ dependencies = [
  "serde",
  "unsafe-libyaml",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ sha2 = "0.10"
 tower = { version = "0.5", features = ["util"] }
 jsonwebtoken = "9"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+redis = { version = "0.27", features = ["tokio-comp", "script"], default-features = false }

--- a/controlplane/Cargo.toml
+++ b/controlplane/Cargo.toml
@@ -20,6 +20,7 @@ sha2 = { workspace = true }
 jsonwebtoken = { workspace = true }
 reqwest = { workspace = true }
 thiserror = { workspace = true }
+redis = { workspace = true }
 
 [dev-dependencies]
 tower = { workspace = true }

--- a/controlplane/src/admin/handlers.rs
+++ b/controlplane/src/admin/handlers.rs
@@ -23,7 +23,7 @@ pub(crate) async fn readyz(State(state): State<SharedState>) -> impl IntoRespons
     let response = ReadyResponse {
         ok: true,
         config_loaded: true,
-        redis_ok: true, // TODO(#12): real Redis check
+        redis_ok: state.rate_limiter.ping().await,
         jwks_ok,
         last_config_reload_unix: cs.last_reload_unix,
     };
@@ -149,11 +149,13 @@ mod tests {
         let yaml = include_str!("../../../examples/configs/gateway-single-node.yaml");
         let cfg = config::load_config_from_str(yaml).unwrap();
         let jwks_registry = crate::auth::JwksCacheRegistry::empty_for_test();
+        let rate_limiter = crate::ratelimit::RateLimiter::offline_for_test(cfg.rate_limits.clone());
         let state = build_state(
             cfg,
             yaml.as_bytes(),
             PathBuf::from("nonexistent.yaml"),
             jwks_registry,
+            rate_limiter,
         );
 
         Router::new()

--- a/controlplane/src/admin/state.rs
+++ b/controlplane/src/admin/state.rs
@@ -7,6 +7,7 @@ use shared::config_types::GatewayConfig;
 use tokio::sync::RwLock;
 
 use crate::auth::JwksCacheRegistry;
+use crate::ratelimit::RateLimiter;
 
 /// Shared application state for the admin API.
 pub(crate) type SharedState = Arc<AppState>;
@@ -16,6 +17,7 @@ pub(crate) struct AppState {
     pub config_state: RwLock<ConfigState>,
     pub config_path: PathBuf,
     pub jwks_registry: Arc<JwksCacheRegistry>,
+    pub rate_limiter: Arc<RateLimiter>,
 }
 
 /// Mutable config state protected by a `RwLock`.
@@ -64,6 +66,7 @@ pub(crate) fn build_state(
     raw_yaml: &[u8],
     config_path: PathBuf,
     jwks_registry: Arc<JwksCacheRegistry>,
+    rate_limiter: Arc<RateLimiter>,
 ) -> SharedState {
     let sha256 = sha256_hex(raw_yaml);
     let now = now_unix();
@@ -78,6 +81,7 @@ pub(crate) fn build_state(
         }),
         config_path,
         jwks_registry,
+        rate_limiter,
     })
 }
 

--- a/controlplane/src/main.rs
+++ b/controlplane/src/main.rs
@@ -7,6 +7,7 @@ use tracing_subscriber::EnvFilter;
 mod admin;
 mod auth;
 mod config;
+mod ratelimit;
 
 #[tokio::main]
 async fn main() {
@@ -54,7 +55,13 @@ async fn main() {
     };
     jwks_registry.spawn_all_refresh_loops();
 
-    let state = admin::state::build_state(cfg, &raw_yaml, config_path, jwks_registry);
+    let rate_limiter = ratelimit::RateLimiter::from_config(&cfg.rate_limits).await;
+    tracing::info!(
+        redis_reachable = rate_limiter.ping().await,
+        "rate limiter initialized"
+    );
+
+    let state = admin::state::build_state(cfg, &raw_yaml, config_path, jwks_registry, rate_limiter);
     let app = admin::router(state);
 
     let listener = TcpListener::bind(&admin_addr).await.unwrap_or_else(|e| {

--- a/controlplane/src/ratelimit/bucket.rs
+++ b/controlplane/src/ratelimit/bucket.rs
@@ -1,0 +1,123 @@
+use std::time::Instant;
+
+/// In-memory token bucket for survivability mode fallback.
+///
+/// Each bucket tracks its own token count and refills based on elapsed
+/// wall-clock time since the last refill.
+pub(crate) struct LocalBucket {
+    tokens: f64,
+    capacity: f64,
+    refill_rate: f64,
+    last_refill: Instant,
+}
+
+impl LocalBucket {
+    /// Create a new bucket starting at full capacity.
+    pub(crate) fn new(capacity: f64, refill_rate: f64) -> Self {
+        Self {
+            tokens: capacity,
+            capacity,
+            refill_rate,
+            last_refill: Instant::now(),
+        }
+    }
+
+    /// Attempt to consume one token.
+    ///
+    /// Returns `(allowed, remaining_tokens, retry_after_ms)`.
+    pub(crate) fn try_consume(&mut self) -> (bool, u64, u64) {
+        self.refill();
+
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            (true, self.tokens.floor() as u64, 0)
+        } else {
+            let deficit = 1.0 - self.tokens;
+            let retry_ms = if self.refill_rate > 0.0 {
+                ((deficit / self.refill_rate) * 1000.0).ceil() as u64
+            } else {
+                u64::MAX
+            };
+            (false, 0, retry_ms)
+        }
+    }
+
+    fn refill(&mut self) {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        let refilled = self.refill_rate * elapsed;
+        self.tokens = (self.tokens + refilled).min(self.capacity);
+        self.last_refill = now;
+    }
+}
+
+/// Compute Redis TTL for a bucket: `ceil((capacity / refill_rate) * 2)`.
+pub(crate) fn ttl_seconds(capacity: u64, refill_rate: f64) -> usize {
+    if refill_rate <= 0.0 {
+        return 3600; // fallback: 1 hour
+    }
+    ((capacity as f64 / refill_rate) * 2.0).ceil() as usize
+}
+
+/// Build a Redis key from components.
+pub(crate) fn build_key(prefix: &str, route: &str, dimension: &str, value: &str) -> String {
+    format!("{prefix}:{route}:{dimension}:{value}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bucket_starts_full() {
+        let mut b = LocalBucket::new(10.0, 1.0);
+        let (allowed, remaining, _) = b.try_consume();
+        assert!(allowed);
+        assert_eq!(remaining, 9);
+    }
+
+    #[test]
+    fn bucket_exhausted_returns_denied() {
+        let mut b = LocalBucket::new(3.0, 0.0);
+        assert!(b.try_consume().0);
+        assert!(b.try_consume().0);
+        assert!(b.try_consume().0);
+        let (allowed, remaining, retry) = b.try_consume();
+        assert!(!allowed);
+        assert_eq!(remaining, 0);
+        assert_eq!(retry, u64::MAX); // zero refill rate
+    }
+
+    #[test]
+    fn retry_after_ms_nonzero_when_denied() {
+        let mut b = LocalBucket::new(1.0, 10.0);
+        b.try_consume(); // depletes the single token
+        let (allowed, _, retry) = b.try_consume();
+        assert!(!allowed);
+        assert!(retry > 0);
+    }
+
+    #[test]
+    fn ttl_formula() {
+        assert_eq!(ttl_seconds(50, 10.0), 10);
+        assert_eq!(ttl_seconds(100, 10.0), 20);
+        assert_eq!(ttl_seconds(1, 1.0), 2);
+    }
+
+    #[test]
+    fn ttl_zero_refill_fallback() {
+        assert_eq!(ttl_seconds(50, 0.0), 3600);
+    }
+
+    #[test]
+    fn key_format() {
+        let key = build_key("rl", "public-api", "ip", "192.168.1.20");
+        assert_eq!(key, "rl:public-api:ip:192.168.1.20");
+    }
+
+    #[test]
+    fn key_format_sub() {
+        let key = build_key("rl", "private-api", "sub", "user-123");
+        assert_eq!(key, "rl:private-api:sub:user-123");
+    }
+}

--- a/controlplane/src/ratelimit/error.rs
+++ b/controlplane/src/ratelimit/error.rs
@@ -1,0 +1,14 @@
+/// Rate-limiting errors.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum RateLimitError {
+    #[error("redis connection error: {0}")]
+    RedisConnect(String),
+    #[error("redis command error: {0}")]
+    RedisCommand(String),
+    #[error("redis timeout")]
+    Timeout,
+    #[error("rate limiter unavailable")]
+    Unavailable,
+    #[error("lua response parse error: {0}")]
+    LuaResponseParse(String),
+}

--- a/controlplane/src/ratelimit/limiter.rs
+++ b/controlplane/src/ratelimit/limiter.rs
@@ -1,0 +1,317 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use redis::aio::MultiplexedConnection;
+use shared::config_types::RateLimitsConfig;
+use tokio::sync::{Mutex, RwLock};
+
+use super::bucket::{ttl_seconds, LocalBucket};
+use super::error::RateLimitError;
+use super::lua::{LuaResponse, LUA_SCRIPT};
+
+/// Decision returned by [`RateLimiter::check`].
+#[derive(Debug)]
+pub(crate) struct RateDecision {
+    pub allowed: bool,
+    pub limit: u64,
+    pub remaining: u64,
+    pub retry_after_ms: u64,
+    pub mode: RateLimitMode,
+}
+
+/// Which backend served the rate-limit decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RateLimitMode {
+    Redis,
+    DegradedLocal,
+    FailOpen,
+}
+
+impl RateLimitMode {
+    pub(crate) fn as_header_value(self) -> &'static str {
+        match self {
+            Self::Redis | Self::FailOpen => "redis",
+            Self::DegradedLocal => "degraded-local",
+        }
+    }
+}
+
+/// Token bucket rate limiter backed by Redis + Lua with in-memory fallback.
+pub(crate) struct RateLimiter {
+    config: RateLimitsConfig,
+    client: redis::Client,
+    conn: Arc<Mutex<Option<MultiplexedConnection>>>,
+    script: redis::Script,
+    fallback: RwLock<HashMap<String, LocalBucket>>,
+}
+
+impl RateLimiter {
+    /// Build and attempt initial Redis connection.
+    ///
+    /// Never fails: if Redis is unreachable, the limiter starts in degraded mode.
+    pub(crate) async fn from_config(config: &RateLimitsConfig) -> Arc<Self> {
+        let url = format!("redis://{}/{}", config.redis_address, config.redis_db);
+        let client = redis::Client::open(url.as_str()).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "invalid redis URL, starting degraded");
+            // Build a client pointing at a dummy address; it will fail on connect.
+            redis::Client::open("redis://invalid:0/0").expect("dummy client")
+        });
+
+        let conn = match tokio::time::timeout(
+            Duration::from_millis(config.default_timeout_ms),
+            client.get_multiplexed_tokio_connection(),
+        )
+        .await
+        {
+            Ok(Ok(c)) => {
+                tracing::info!("redis connected");
+                Some(c)
+            }
+            Ok(Err(e)) => {
+                tracing::warn!(error = %e, "redis connection failed, starting degraded");
+                None
+            }
+            Err(_) => {
+                tracing::warn!("redis connection timed out, starting degraded");
+                None
+            }
+        };
+
+        Arc::new(Self {
+            config: config.clone(),
+            client,
+            conn: Arc::new(Mutex::new(conn)),
+            script: redis::Script::new(LUA_SCRIPT),
+            fallback: RwLock::new(HashMap::new()),
+        })
+    }
+
+    /// Check (and deduct) one token for the given bucket key.
+    pub(crate) async fn check(
+        &self,
+        bucket_key: &str,
+        capacity: u64,
+        refill_rate: f64,
+    ) -> Result<RateDecision, RateLimitError> {
+        match self.try_redis(bucket_key, capacity, refill_rate).await {
+            Ok(decision) => Ok(decision),
+            Err(_) => self.enter_degraded(bucket_key, capacity, refill_rate).await,
+        }
+    }
+
+    /// Ping Redis. Returns `true` if reachable within the configured timeout.
+    ///
+    /// Also attempts to re-establish the connection if currently disconnected.
+    pub(crate) async fn ping(&self) -> bool {
+        let mut guard = self.conn.lock().await;
+
+        // Try existing connection first.
+        if let Some(ref mut conn) = *guard {
+            let result = tokio::time::timeout(
+                Duration::from_millis(self.config.default_timeout_ms),
+                redis::cmd("PING").query_async::<String>(conn),
+            )
+            .await;
+            if let Ok(Ok(_)) = result {
+                return true;
+            }
+            // Connection is dead, drop it.
+            *guard = None;
+        }
+
+        // Attempt reconnection.
+        match tokio::time::timeout(
+            Duration::from_millis(self.config.default_timeout_ms),
+            self.client.get_multiplexed_tokio_connection(),
+        )
+        .await
+        {
+            Ok(Ok(new_conn)) => {
+                *guard = Some(new_conn);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    async fn try_redis(
+        &self,
+        bucket_key: &str,
+        capacity: u64,
+        refill_rate: f64,
+    ) -> Result<RateDecision, RateLimitError> {
+        let mut guard = self.conn.lock().await;
+        let conn = guard
+            .as_mut()
+            .ok_or(RateLimitError::RedisConnect("no active connection".into()))?;
+
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        let ttl = ttl_seconds(capacity, refill_rate);
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(self.config.default_timeout_ms),
+            self.script
+                .key(bucket_key)
+                .arg(now_ms)
+                .arg(capacity)
+                .arg(refill_rate)
+                .arg(1u64) // requested tokens
+                .arg(ttl)
+                .invoke_async::<String>(conn),
+        )
+        .await;
+
+        match result {
+            Ok(Ok(json_str)) => {
+                let resp: LuaResponse = serde_json::from_str(&json_str)
+                    .map_err(|e| RateLimitError::LuaResponseParse(e.to_string()))?;
+                Ok(RateDecision {
+                    allowed: resp.allowed == 1,
+                    limit: capacity,
+                    remaining: resp.remaining_tokens,
+                    retry_after_ms: resp.retry_after_ms,
+                    mode: RateLimitMode::Redis,
+                })
+            }
+            Ok(Err(e)) => {
+                // Redis command error — mark connection dead.
+                *guard = None;
+                Err(RateLimitError::RedisCommand(e.to_string()))
+            }
+            Err(_) => {
+                *guard = None;
+                Err(RateLimitError::Timeout)
+            }
+        }
+    }
+
+    async fn enter_degraded(
+        &self,
+        bucket_key: &str,
+        capacity: u64,
+        _refill_rate: f64,
+    ) -> Result<RateDecision, RateLimitError> {
+        let sm = &self.config.survivability_mode;
+
+        if sm.enabled {
+            let mut map = self.fallback.write().await;
+            let bucket = map.entry(bucket_key.to_string()).or_insert_with(|| {
+                LocalBucket::new(sm.fallback_capacity as f64, sm.fallback_refill_rate_per_sec)
+            });
+
+            let (allowed, remaining, retry_after_ms) = bucket.try_consume();
+            return Ok(RateDecision {
+                allowed,
+                limit: sm.fallback_capacity,
+                remaining,
+                retry_after_ms,
+                mode: RateLimitMode::DegradedLocal,
+            });
+        }
+
+        if self.config.fail_open {
+            tracing::warn!(key = %bucket_key, "redis unavailable, fail_open=true, allowing");
+            return Ok(RateDecision {
+                allowed: true,
+                limit: capacity,
+                remaining: capacity,
+                retry_after_ms: 0,
+                mode: RateLimitMode::FailOpen,
+            });
+        }
+
+        Err(RateLimitError::Unavailable)
+    }
+}
+
+#[cfg(test)]
+impl RateLimiter {
+    /// Create an offline limiter for tests (no Redis connection).
+    pub(crate) fn offline_for_test(config: RateLimitsConfig) -> Arc<Self> {
+        let client = redis::Client::open("redis://invalid:0/0").expect("dummy client for test");
+        Arc::new(Self {
+            config,
+            client,
+            conn: Arc::new(Mutex::new(None)),
+            script: redis::Script::new(LUA_SCRIPT),
+            fallback: RwLock::new(HashMap::new()),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use shared::config_types::SurvivabilityMode;
+
+    use super::*;
+
+    fn test_config(fail_open: bool, survivability_enabled: bool) -> RateLimitsConfig {
+        RateLimitsConfig {
+            redis_address: "invalid:0".into(),
+            redis_db: 0,
+            redis_key_prefix: "rl".into(),
+            default_timeout_ms: 50,
+            fail_open,
+            survivability_mode: SurvivabilityMode {
+                enabled: survivability_enabled,
+                fallback_capacity: 5,
+                fallback_refill_rate_per_sec: 1.0,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn fail_open_allows_when_offline() {
+        let limiter = RateLimiter::offline_for_test(test_config(true, false));
+        let result = limiter.check("rl:test:ip:1.2.3.4", 10, 1.0).await;
+        let decision = result.unwrap();
+        assert!(decision.allowed);
+        assert_eq!(decision.mode, RateLimitMode::FailOpen);
+    }
+
+    #[tokio::test]
+    async fn fail_closed_returns_unavailable() {
+        let limiter = RateLimiter::offline_for_test(test_config(false, false));
+        let result = limiter.check("rl:test:ip:1.2.3.4", 10, 1.0).await;
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), RateLimitError::Unavailable));
+    }
+
+    #[tokio::test]
+    async fn survivability_mode_uses_local_bucket() {
+        let limiter = RateLimiter::offline_for_test(test_config(false, true));
+
+        // Fallback capacity is 5.
+        for i in 0..5 {
+            let d = limiter.check("rl:test:ip:1.2.3.4", 10, 1.0).await.unwrap();
+            assert!(d.allowed, "request {i} should be allowed");
+            assert_eq!(d.mode, RateLimitMode::DegradedLocal);
+        }
+
+        // 6th request should be denied.
+        let d = limiter.check("rl:test:ip:1.2.3.4", 10, 1.0).await.unwrap();
+        assert!(!d.allowed);
+        assert_eq!(d.mode, RateLimitMode::DegradedLocal);
+        assert!(d.retry_after_ms > 0);
+    }
+
+    #[tokio::test]
+    async fn ping_offline_returns_false() {
+        let limiter = RateLimiter::offline_for_test(test_config(true, false));
+        assert!(!limiter.ping().await);
+    }
+
+    #[test]
+    fn rate_limit_mode_header_values() {
+        assert_eq!(RateLimitMode::Redis.as_header_value(), "redis");
+        assert_eq!(
+            RateLimitMode::DegradedLocal.as_header_value(),
+            "degraded-local"
+        );
+        assert_eq!(RateLimitMode::FailOpen.as_header_value(), "redis");
+    }
+}

--- a/controlplane/src/ratelimit/lua.rs
+++ b/controlplane/src/ratelimit/lua.rs
@@ -1,0 +1,64 @@
+/// Lua script for atomic token bucket execution in Redis.
+///
+/// Inputs: KEYS[1]=bucket_key, ARGV[1..5]=now_ms, capacity, refill_rate, requested, ttl.
+/// Output: JSON string with {allowed, remaining_tokens, retry_after_ms}.
+pub(crate) const LUA_SCRIPT: &str = r#"
+local key = KEYS[1]
+local now_ms       = tonumber(ARGV[1])
+local capacity     = tonumber(ARGV[2])
+local refill_rate  = tonumber(ARGV[3])
+local requested    = tonumber(ARGV[4])
+local ttl_seconds  = tonumber(ARGV[5])
+
+local tokens        = tonumber(redis.call('HGET', key, 'tokens'))
+local last_refill   = tonumber(redis.call('HGET', key, 'last_refill_ms'))
+
+if tokens == nil then tokens = capacity end
+if last_refill == nil then last_refill = now_ms end
+
+local elapsed_s     = (now_ms - last_refill) / 1000.0
+local refilled      = refill_rate * elapsed_s
+local new_tokens    = math.min(tokens + refilled, capacity)
+
+if new_tokens >= requested then
+    new_tokens = new_tokens - requested
+    redis.call('HSET', key, 'tokens', tostring(new_tokens), 'last_refill_ms', tostring(now_ms))
+    redis.call('EXPIRE', key, ttl_seconds)
+    return '{"allowed":1,"remaining_tokens":' .. math.floor(new_tokens) .. ',"retry_after_ms":0}'
+else
+    local deficit = requested - new_tokens
+    local retry_ms = math.ceil((deficit / refill_rate) * 1000)
+    return '{"allowed":0,"remaining_tokens":0,"retry_after_ms":' .. retry_ms .. '}'
+end
+"#;
+
+/// Deserialised response from the Lua script.
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct LuaResponse {
+    pub allowed: u8,
+    pub remaining_tokens: u64,
+    pub retry_after_ms: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_allowed_response() {
+        let json = r#"{"allowed":1,"remaining_tokens":9,"retry_after_ms":0}"#;
+        let resp: LuaResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.allowed, 1);
+        assert_eq!(resp.remaining_tokens, 9);
+        assert_eq!(resp.retry_after_ms, 0);
+    }
+
+    #[test]
+    fn parse_denied_response() {
+        let json = r#"{"allowed":0,"remaining_tokens":0,"retry_after_ms":180}"#;
+        let resp: LuaResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.allowed, 0);
+        assert_eq!(resp.remaining_tokens, 0);
+        assert_eq!(resp.retry_after_ms, 180);
+    }
+}

--- a/controlplane/src/ratelimit/mod.rs
+++ b/controlplane/src/ratelimit/mod.rs
@@ -1,0 +1,14 @@
+// Rate limiting subsystem: token bucket with Redis + Lua primary
+// and in-memory fallback for survivability mode.
+#[allow(dead_code)]
+mod bucket;
+#[allow(dead_code)]
+mod error;
+#[allow(dead_code)]
+pub(crate) mod limiter;
+#[allow(dead_code)]
+mod lua;
+
+#[allow(dead_code, unused_imports)]
+pub(crate) use error::RateLimitError;
+pub(crate) use limiter::RateLimiter;

--- a/docs/adr/0002-redis-rate-limiter-crate.md
+++ b/docs/adr/0002-redis-rate-limiter-crate.md
@@ -1,0 +1,30 @@
+# ADR 0002: Redis Client Crate Selection for Rate Limiting
+
+Status: Accepted
+
+## Context
+
+Issue #12 requires atomic token bucket execution on Redis via Lua script,
+a multiplexed async connection, configurable command timeouts, and EVALSHA
+with EVAL fallback.
+
+## Decision
+
+`redis = { version = "0.27", features = ["tokio-comp", "script"], default-features = false }`
+
+## Rationale
+
+- `redis::Script` provides EVALSHA with automatic EVAL fallback and SHA1 caching.
+- `MultiplexedConnection` is Tokio-native and cheaply cloneable.
+- `tokio-comp` gives full async/await without a sync thread pool.
+- Minimal transitive deps with `default-features = false`.
+- Alternative considered: `fred` -- more features (pooling, cluster, sentinel)
+  but heavier dependency graph and not needed for single-node v1.
+- Alternative considered: `deadpool-redis` -- pool layer unnecessary for a
+  single multiplexed connection.
+
+## Consequences
+
+- Binary size increase ~0.8 MB.
+- No native-TLS or OpenSSL dependency (default-features disabled).
+- Scoped to controlplane only; shared and dataplane unaffected.


### PR DESCRIPTION
## Summary
- Adds atomic token bucket rate limiting via Redis Lua script (EVALSHA/EVAL with automatic fallback)
- Three degraded-mode branches when Redis is unreachable: survivability local bucket, fail-open, fail-closed (503)
- Wires `RateLimiter` into admin state; `readyz` now reports real `redis_ok` health
- ADR 0002 documents redis crate selection (`redis 0.27` with `tokio-comp` + `script`)

## New files
| File | Purpose |
|------|---------|
| `controlplane/src/ratelimit/error.rs` | `RateLimitError` enum |
| `controlplane/src/ratelimit/lua.rs` | Lua script constant + `LuaResponse` |
| `controlplane/src/ratelimit/bucket.rs` | Pure token bucket arithmetic (`LocalBucket`) |
| `controlplane/src/ratelimit/limiter.rs` | `RateLimiter` struct: Redis client, fallback, `check()`, `ping()` |
| `controlplane/src/ratelimit/mod.rs` | Module wiring |
| `docs/adr/0002-redis-rate-limiter-crate.md` | ADR for redis crate |

## Test plan
- [x] 7 bucket arithmetic tests (start full, exhaust, refill cap, TTL formula, key format)
- [x] 5 limiter tests (fail_open, fail_closed, survivability_mode, ping_offline, header values)
- [x] 2 Lua response parsing tests
- [x] All 69 workspace tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `bash tools/check-loc.sh` within limits

Closes #12