### PR TITLE
feat: Envoy v3 static config generation

### DIFF
--- a/controlplane/src/config/envoy_gen.rs
+++ b/controlplane/src/config/envoy_gen.rs
@@ -1,0 +1,271 @@
+use serde_yaml::Value;
+use shared::config_types::{GatewayConfig, RouteConfig, ServiceConfig};
+
+/// Errors from Envoy config generation.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum EnvoyGenError {
+    #[error("invalid endpoint format '{0}': expected host:port")]
+    InvalidEndpoint(String),
+    #[error("YAML serialization error: {0}")]
+    Serialization(#[from] serde_yaml::Error),
+}
+
+/// Generate a complete Envoy v3 static bootstrap config from a gateway config.
+///
+/// The output is a YAML string ready to write to `/etc/envoy/envoy.yaml`.
+pub(crate) fn generate_envoy_config(cfg: &GatewayConfig) -> Result<String, EnvoyGenError> {
+    let listener = build_listener(cfg)?;
+    let clusters = build_clusters(&cfg.services)?;
+
+    let root = serde_yaml::to_value(serde_yaml::Mapping::new())?;
+    let mut root = match root {
+        Value::Mapping(m) => m,
+        _ => serde_yaml::Mapping::new(),
+    };
+
+    // static_resources
+    let mut static_resources = serde_yaml::Mapping::new();
+    static_resources.insert(val("listeners"), Value::Sequence(vec![listener]));
+    static_resources.insert(val("clusters"), Value::Sequence(clusters));
+    root.insert(val("static_resources"), Value::Mapping(static_resources));
+
+    // Envoy admin interface on localhost:9901
+    root.insert(val("admin"), build_admin());
+
+    serde_yaml::to_string(&Value::Mapping(root)).map_err(EnvoyGenError::from)
+}
+
+/// Build the main listener with HCM filter and route config.
+fn build_listener(cfg: &GatewayConfig) -> Result<Value, EnvoyGenError> {
+    let (listen_host, listen_port) = parse_endpoint(&cfg.gateway.listen_address)?;
+    let virtual_hosts = build_virtual_hosts(&cfg.routes);
+
+    let mut route_config = serde_yaml::Mapping::new();
+    route_config.insert(val("name"), val("local_route"));
+    route_config.insert(val("virtual_hosts"), Value::Sequence(virtual_hosts));
+
+    let mut hcm_typed_config = serde_yaml::Mapping::new();
+    hcm_typed_config.insert(
+        val("@type"),
+        val("type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"),
+    );
+    hcm_typed_config.insert(val("stat_prefix"), val("ingress_http"));
+    hcm_typed_config.insert(val("generate_request_id"), Value::Bool(true));
+
+    // Stream idle timeout from gateway config.
+    let mut common_http = serde_yaml::Mapping::new();
+    common_http.insert(
+        val("idle_timeout"),
+        val(&duration_string(cfg.gateway.idle_timeout_ms)),
+    );
+    hcm_typed_config.insert(
+        val("common_http_protocol_options"),
+        Value::Mapping(common_http),
+    );
+
+    hcm_typed_config.insert(val("route_config"), Value::Mapping(route_config));
+
+    // Router filter
+    let mut router_typed = serde_yaml::Mapping::new();
+    router_typed.insert(
+        val("@type"),
+        val("type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"),
+    );
+    let mut router_filter = serde_yaml::Mapping::new();
+    router_filter.insert(val("name"), val("envoy.filters.http.router"));
+    router_filter.insert(val("typed_config"), Value::Mapping(router_typed));
+
+    hcm_typed_config.insert(
+        val("http_filters"),
+        Value::Sequence(vec![Value::Mapping(router_filter)]),
+    );
+
+    let mut hcm_filter = serde_yaml::Mapping::new();
+    hcm_filter.insert(
+        val("name"),
+        val("envoy.filters.network.http_connection_manager"),
+    );
+    hcm_filter.insert(val("typed_config"), Value::Mapping(hcm_typed_config));
+
+    let mut filter_chain = serde_yaml::Mapping::new();
+    filter_chain.insert(
+        val("filters"),
+        Value::Sequence(vec![Value::Mapping(hcm_filter)]),
+    );
+
+    let mut listener = serde_yaml::Mapping::new();
+    listener.insert(val("name"), val("main_listener"));
+    listener.insert(
+        val("address"),
+        build_socket_address(&listen_host, listen_port),
+    );
+    listener.insert(
+        val("filter_chains"),
+        Value::Sequence(vec![Value::Mapping(filter_chain)]),
+    );
+
+    Ok(Value::Mapping(listener))
+}
+
+/// Build virtual hosts from gateway routes.
+fn build_virtual_hosts(routes: &[RouteConfig]) -> Vec<Value> {
+    routes.iter().map(build_virtual_host).collect()
+}
+
+/// Build a single virtual host from a gateway route.
+fn build_virtual_host(route: &RouteConfig) -> Value {
+    let domains: Vec<Value> = route.hostnames.iter().map(|h| val(h)).collect();
+
+    let mut match_rule = serde_yaml::Mapping::new();
+    match_rule.insert(val("prefix"), val(&route.path_prefix));
+
+    let mut route_action = serde_yaml::Mapping::new();
+    route_action.insert(val("cluster"), val(&route.upstream.service));
+    route_action.insert(
+        val("timeout"),
+        val(&duration_string(route.upstream.request_timeout_ms)),
+    );
+
+    if route.upstream.retries > 0 {
+        let mut retry_policy = serde_yaml::Mapping::new();
+        retry_policy.insert(val("retry_on"), val("5xx,connect-failure"));
+        retry_policy.insert(
+            val("num_retries"),
+            Value::Number(serde_yaml::Number::from(route.upstream.retries as u64)),
+        );
+        route_action.insert(val("retry_policy"), Value::Mapping(retry_policy));
+    }
+
+    let mut route_entry = serde_yaml::Mapping::new();
+    route_entry.insert(val("match"), Value::Mapping(match_rule));
+    route_entry.insert(val("route"), Value::Mapping(route_action));
+
+    let mut vhost = serde_yaml::Mapping::new();
+    vhost.insert(val("name"), val(&route.name));
+    vhost.insert(val("domains"), Value::Sequence(domains));
+    vhost.insert(
+        val("routes"),
+        Value::Sequence(vec![Value::Mapping(route_entry)]),
+    );
+
+    Value::Mapping(vhost)
+}
+
+/// Build clusters from gateway services.
+fn build_clusters(services: &[ServiceConfig]) -> Result<Vec<Value>, EnvoyGenError> {
+    services.iter().map(build_cluster).collect()
+}
+
+/// Build a single Envoy cluster from a gateway service.
+fn build_cluster(service: &ServiceConfig) -> Result<Value, EnvoyGenError> {
+    let mut lb_endpoints = Vec::new();
+    for ep in &service.endpoints {
+        let (host, port) = parse_endpoint(ep)?;
+        let mut lb_ep = serde_yaml::Mapping::new();
+        lb_ep.insert(val("endpoint"), build_socket_address(&host, port));
+        lb_endpoints.push(Value::Mapping(lb_ep));
+    }
+
+    let mut endpoint_group = serde_yaml::Mapping::new();
+    endpoint_group.insert(val("lb_endpoints"), Value::Sequence(lb_endpoints));
+
+    let mut load_assignment = serde_yaml::Mapping::new();
+    load_assignment.insert(val("cluster_name"), val(&service.name));
+    load_assignment.insert(
+        val("endpoints"),
+        Value::Sequence(vec![Value::Mapping(endpoint_group)]),
+    );
+
+    let health_check = build_health_check(service);
+
+    let mut cluster = serde_yaml::Mapping::new();
+    cluster.insert(val("name"), val(&service.name));
+    cluster.insert(val("type"), val("STRICT_DNS"));
+    cluster.insert(val("lb_policy"), val("ROUND_ROBIN"));
+    cluster.insert(
+        val("connect_timeout"),
+        val(&duration_string(service.health_check.timeout_ms)),
+    );
+    cluster.insert(val("load_assignment"), Value::Mapping(load_assignment));
+    cluster.insert(val("health_checks"), Value::Sequence(vec![health_check]));
+
+    Ok(Value::Mapping(cluster))
+}
+
+/// Build an HTTP health check for a cluster.
+fn build_health_check(service: &ServiceConfig) -> Value {
+    let hc = &service.health_check;
+
+    let mut http_hc = serde_yaml::Mapping::new();
+    http_hc.insert(val("path"), val(&hc.path));
+
+    let mut check = serde_yaml::Mapping::new();
+    check.insert(val("timeout"), val(&duration_string(hc.timeout_ms)));
+    check.insert(val("interval"), val(&duration_string(hc.interval_ms)));
+    check.insert(val("http_health_check"), Value::Mapping(http_hc));
+
+    Value::Mapping(check)
+}
+
+/// Build the Envoy admin section (localhost:9901).
+fn build_admin() -> Value {
+    let mut admin = serde_yaml::Mapping::new();
+    admin.insert(val("address"), build_socket_address("127.0.0.1", 9901));
+    Value::Mapping(admin)
+}
+
+/// Build an Envoy socket_address block.
+fn build_socket_address(host: &str, port: u16) -> Value {
+    let mut sa = serde_yaml::Mapping::new();
+    sa.insert(val("address"), val(host));
+    sa.insert(
+        val("port_value"),
+        Value::Number(serde_yaml::Number::from(port as u64)),
+    );
+
+    let mut address = serde_yaml::Mapping::new();
+    address.insert(val("socket_address"), Value::Mapping(sa));
+    Value::Mapping(address)
+}
+
+/// Parse a "host:port" endpoint string.
+fn parse_endpoint(endpoint: &str) -> Result<(String, u16), EnvoyGenError> {
+    let colon_pos = endpoint
+        .rfind(':')
+        .ok_or_else(|| EnvoyGenError::InvalidEndpoint(endpoint.to_owned()))?;
+
+    let host = &endpoint[..colon_pos];
+    let port_str = &endpoint[colon_pos + 1..];
+
+    if host.is_empty() {
+        return Err(EnvoyGenError::InvalidEndpoint(endpoint.to_owned()));
+    }
+
+    let port: u16 = port_str
+        .parse()
+        .map_err(|_| EnvoyGenError::InvalidEndpoint(endpoint.to_owned()))?;
+
+    Ok((host.to_owned(), port))
+}
+
+/// Convert milliseconds to an Envoy duration string.
+///
+/// Envoy expects durations like "5s", "0.500s", "0.050s".
+fn duration_string(ms: u64) -> String {
+    let secs = ms / 1000;
+    let frac = ms % 1000;
+    if frac == 0 {
+        format!("{secs}s")
+    } else {
+        format!("{secs}.{frac:03}s")
+    }
+}
+
+/// Shorthand to create a `serde_yaml::Value::String`.
+fn val(s: &str) -> Value {
+    Value::String(s.to_owned())
+}
+
+#[cfg(test)]
+#[path = "envoy_gen_tests.rs"]
+mod tests;

--- a/controlplane/src/config/envoy_gen_tests.rs
+++ b/controlplane/src/config/envoy_gen_tests.rs
@@ -1,0 +1,192 @@
+use serde_yaml::Value;
+
+use super::*;
+
+fn sample_config() -> GatewayConfig {
+    let yaml = include_str!("../../../examples/configs/gateway-single-node.yaml");
+    serde_yaml::from_str(yaml).unwrap()
+}
+
+fn generate_and_parse(cfg: &GatewayConfig) -> Value {
+    let yaml_str = generate_envoy_config(cfg).unwrap();
+    serde_yaml::from_str(&yaml_str).unwrap()
+}
+
+#[test]
+fn generate_from_sample_config() {
+    let cfg = sample_config();
+    let envoy = generate_and_parse(&cfg);
+
+    // Top-level keys exist.
+    assert!(envoy["static_resources"].is_mapping());
+    assert!(envoy["admin"].is_mapping());
+
+    // Listeners and clusters present.
+    let listeners = &envoy["static_resources"]["listeners"];
+    assert!(listeners.is_sequence());
+    assert_eq!(listeners.as_sequence().unwrap().len(), 1);
+
+    let clusters = &envoy["static_resources"]["clusters"];
+    assert!(clusters.is_sequence());
+    assert_eq!(clusters.as_sequence().unwrap().len(), cfg.services.len());
+}
+
+#[test]
+fn listener_address_from_config() {
+    let cfg = sample_config();
+    let envoy = generate_and_parse(&cfg);
+
+    let addr = &envoy["static_resources"]["listeners"][0]["address"]["socket_address"];
+    assert_eq!(addr["address"].as_str().unwrap(), "0.0.0.0");
+    assert_eq!(addr["port_value"].as_u64().unwrap(), 8080);
+}
+
+#[test]
+fn virtual_hosts_from_routes() {
+    let cfg = sample_config();
+    let envoy = generate_and_parse(&cfg);
+
+    let hcm = &envoy["static_resources"]["listeners"][0]["filter_chains"][0]["filters"][0]
+        ["typed_config"];
+    let vhosts = hcm["route_config"]["virtual_hosts"].as_sequence().unwrap();
+    assert_eq!(vhosts.len(), cfg.routes.len());
+
+    // First route: public-echo
+    let vh0 = &vhosts[0];
+    assert_eq!(vh0["name"].as_str().unwrap(), "public-echo");
+    let domains: Vec<&str> = vh0["domains"]
+        .as_sequence()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(domains.contains(&"localhost"));
+    assert!(domains.contains(&"127.0.0.1"));
+
+    let route = &vh0["routes"][0];
+    assert_eq!(route["match"]["prefix"].as_str().unwrap(), "/public");
+    assert_eq!(route["route"]["cluster"].as_str().unwrap(), "backend");
+}
+
+#[test]
+fn clusters_from_services() {
+    let cfg = sample_config();
+    let envoy = generate_and_parse(&cfg);
+
+    let clusters = envoy["static_resources"]["clusters"].as_sequence().unwrap();
+    let cluster = &clusters[0];
+    assert_eq!(cluster["name"].as_str().unwrap(), "backend");
+    assert_eq!(cluster["type"].as_str().unwrap(), "STRICT_DNS");
+    assert_eq!(cluster["lb_policy"].as_str().unwrap(), "ROUND_ROBIN");
+
+    let ep = &cluster["load_assignment"]["endpoints"][0]["lb_endpoints"][0];
+    let sa = &ep["endpoint"]["socket_address"];
+    assert_eq!(sa["address"].as_str().unwrap(), "echo-backend");
+    assert_eq!(sa["port_value"].as_u64().unwrap(), 8081);
+}
+
+#[test]
+fn health_checks_configured() {
+    let cfg = sample_config();
+    let envoy = generate_and_parse(&cfg);
+
+    let hc = &envoy["static_resources"]["clusters"][0]["health_checks"][0];
+    assert_eq!(
+        hc["http_health_check"]["path"].as_str().unwrap(),
+        "/healthz"
+    );
+    assert_eq!(hc["interval"].as_str().unwrap(), "2s");
+    assert_eq!(hc["timeout"].as_str().unwrap(), "0.500s");
+}
+
+#[test]
+fn timeouts_set() {
+    let cfg = sample_config();
+    let envoy = generate_and_parse(&cfg);
+
+    // Route timeout
+    let hcm = &envoy["static_resources"]["listeners"][0]["filter_chains"][0]["filters"][0]
+        ["typed_config"];
+    let route = &hcm["route_config"]["virtual_hosts"][0]["routes"][0];
+    assert_eq!(route["route"]["timeout"].as_str().unwrap(), "5s");
+
+    // Idle timeout via common_http_protocol_options
+    let idle = &hcm["common_http_protocol_options"]["idle_timeout"];
+    assert_eq!(idle.as_str().unwrap(), "60s");
+}
+
+#[test]
+fn request_id_generation_enabled() {
+    let cfg = sample_config();
+    let envoy = generate_and_parse(&cfg);
+
+    let hcm = &envoy["static_resources"]["listeners"][0]["filter_chains"][0]["filters"][0]
+        ["typed_config"];
+    assert!(hcm["generate_request_id"].as_bool().unwrap());
+}
+
+#[test]
+fn retry_policy_when_retries_nonzero() {
+    let cfg = sample_config();
+    let envoy = generate_and_parse(&cfg);
+
+    // Sample config has retries: 1 on both routes.
+    let hcm = &envoy["static_resources"]["listeners"][0]["filter_chains"][0]["filters"][0]
+        ["typed_config"];
+    let route = &hcm["route_config"]["virtual_hosts"][0]["routes"][0];
+    let retry = &route["route"]["retry_policy"];
+    assert_eq!(retry["num_retries"].as_u64().unwrap(), 1);
+    assert_eq!(retry["retry_on"].as_str().unwrap(), "5xx,connect-failure");
+}
+
+#[test]
+fn no_retry_policy_when_retries_zero() {
+    let mut cfg = sample_config();
+    cfg.routes[0].upstream.retries = 0;
+    let envoy = generate_and_parse(&cfg);
+
+    let hcm = &envoy["static_resources"]["listeners"][0]["filter_chains"][0]["filters"][0]
+        ["typed_config"];
+    let route = &hcm["route_config"]["virtual_hosts"][0]["routes"][0];
+    assert!(route["route"]["retry_policy"].is_null());
+}
+
+#[test]
+fn parse_endpoint_valid() {
+    let (host, port) = parse_endpoint("backend:8080").unwrap();
+    assert_eq!(host, "backend");
+    assert_eq!(port, 8080);
+
+    let (host, port) = parse_endpoint("192.168.1.1:443").unwrap();
+    assert_eq!(host, "192.168.1.1");
+    assert_eq!(port, 443);
+}
+
+#[test]
+fn parse_endpoint_invalid() {
+    assert!(parse_endpoint("no-port").is_err());
+    assert!(parse_endpoint(":8080").is_err());
+    assert!(parse_endpoint("host:abc").is_err());
+    assert!(parse_endpoint("host:99999").is_err());
+}
+
+#[test]
+fn duration_string_formatting() {
+    assert_eq!(duration_string(5000), "5s");
+    assert_eq!(duration_string(500), "0.500s");
+    assert_eq!(duration_string(50), "0.050s");
+    assert_eq!(duration_string(0), "0s");
+    assert_eq!(duration_string(1), "0.001s");
+    assert_eq!(duration_string(15000), "15s");
+    assert_eq!(duration_string(2500), "2.500s");
+}
+
+#[test]
+fn admin_address_is_localhost() {
+    let cfg = sample_config();
+    let envoy = generate_and_parse(&cfg);
+
+    let admin_addr = &envoy["admin"]["address"]["socket_address"];
+    assert_eq!(admin_addr["address"].as_str().unwrap(), "127.0.0.1");
+    assert_eq!(admin_addr["port_value"].as_u64().unwrap(), 9901);
+}

--- a/controlplane/src/config/mod.rs
+++ b/controlplane/src/config/mod.rs
@@ -1,4 +1,9 @@
 mod loader;
 mod validation;
 
+#[allow(dead_code)]
+mod envoy_gen;
+
+#[allow(dead_code)]
+pub(crate) use envoy_gen::generate_envoy_config;
 pub(crate) use loader::load_config_from_str;

--- a/controlplane/src/main.rs
+++ b/controlplane/src/main.rs
@@ -39,6 +39,20 @@ async fn main() {
     });
 
     tracing::info!("controlplane starting");
+
+    // Phase 2.5: Generate and write Envoy config (if path set).
+    if let Ok(envoy_path) = std::env::var("ENVOY_CONFIG_PATH") {
+        let envoy_yaml = config::generate_envoy_config(&cfg).unwrap_or_else(|e| {
+            tracing::error!(error = %e, "failed to generate envoy config");
+            std::process::exit(1);
+        });
+        std::fs::write(&envoy_path, envoy_yaml).unwrap_or_else(|e| {
+            tracing::error!(path = %envoy_path, error = %e, "failed to write envoy config");
+            std::process::exit(1);
+        });
+        tracing::info!(path = %envoy_path, "envoy config written");
+    }
+
     let admin_addr = cfg.gateway.admin_address.clone();
     tracing::info!(
         version = cfg.version,


### PR DESCRIPTION
## Summary

- Add Envoy v3 static config generator that transforms `GatewayConfig` into complete Envoy bootstrap YAML
- Builds listeners (HCM filter, virtual hosts, route matching), clusters (endpoints, health checks, LB policy), timeouts, retry policies, and x-request-id generation programmatically via `serde_yaml::Value` trees
- Writes generated config to `ENVOY_CONFIG_PATH` env var on startup (no-op when unset)
- 13 new tests covering round-trip generation, endpoint parsing, duration formatting, and all config sections

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` -- 101 tests pass (13 new for envoy_gen)
- [x] `bash tools/check-loc.sh` -- all files within LOC limits
- [ ] CI pipeline passes

Closes https://github.com/shikarii/OpenApiGateway/issues/14
