### PR TITLE
feat: comprehensive JWT/auth test suite

### DIFF
--- a/controlplane/Cargo.toml
+++ b/controlplane/Cargo.toml
@@ -30,3 +30,4 @@ tracing-opentelemetry = { workspace = true }
 
 [dev-dependencies]
 tower = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }

--- a/controlplane/src/auth/integration_tests.rs
+++ b/controlplane/src/auth/integration_tests.rs
@@ -1,0 +1,139 @@
+use jsonwebtoken::{encode, Algorithm, DecodingKey, EncodingKey, Header};
+use shared::config_types::AuthProvider;
+use std::time::{Duration, Instant};
+
+use super::error::AuthError;
+use super::jwks_cache::JwksCache;
+use super::types::JwksKey;
+use super::validate_with_refresh;
+
+// ── helpers (duplicated from validator_tests to keep files independent) ──
+
+fn rsa_key_pair() -> (EncodingKey, DecodingKey) {
+    let priv_pem = include_bytes!("../../../test_fixtures/rsa_private.pem");
+    let pub_pem = include_bytes!("../../../test_fixtures/rsa_public.pem");
+    (
+        EncodingKey::from_rsa_pem(priv_pem).expect("test private key"),
+        DecodingKey::from_rsa_pem(pub_pem).expect("test public key"),
+    )
+}
+
+fn test_provider() -> AuthProvider {
+    AuthProvider {
+        name: "test".into(),
+        issuer: "https://auth.example.com/".into(),
+        audience: "api-gateway".into(),
+        jwks_uri: "http://localhost/.well-known/jwks.json".into(),
+        cache_ttl_seconds: 300,
+        clock_skew_seconds: 30,
+    }
+}
+
+fn make_jwks_keys(decoding_key: DecodingKey, kid: &str) -> Vec<JwksKey> {
+    vec![JwksKey {
+        kid: kid.to_string(),
+        decoding_key,
+    }]
+}
+
+#[derive(Debug, serde::Serialize)]
+struct TestClaims {
+    sub: Option<String>,
+    iss: Option<String>,
+    aud: serde_json::Value,
+    exp: i64,
+    nbf: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scope: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scp: Option<Vec<String>>,
+}
+
+fn default_claims() -> TestClaims {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before epoch")
+        .as_secs() as i64;
+    TestClaims {
+        sub: Some("user-123".into()),
+        iss: Some("https://auth.example.com/".into()),
+        aud: serde_json::json!("api-gateway"),
+        exp: now + 3600,
+        nbf: now - 60,
+        scope: Some("api.read api.write".into()),
+        scp: None,
+    }
+}
+
+fn encode_token(claims: &TestClaims, enc_key: &EncodingKey, kid: &str) -> String {
+    let mut header = Header::new(Algorithm::RS256);
+    header.kid = Some(kid.to_string());
+    encode(&header, claims, enc_key).expect("encode failed")
+}
+
+// ── integration tests ──
+
+#[tokio::test]
+async fn stale_cache_returns_provider_unavailable() {
+    let provider = test_provider();
+    let old = Instant::now() - Duration::from_secs(7200);
+    // TTL=1, STALE_FACTOR=10 → threshold 10s; elapsed ~7200s → stale.
+    let stale_provider = AuthProvider {
+        cache_ttl_seconds: 1,
+        ..provider.clone()
+    };
+    let cache = JwksCache::for_test(stale_provider, vec![], old);
+    let err = validate_with_refresh("dummy.token.here", &provider, &cache, &[])
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, AuthError::AuthProviderUnavailable),
+        "expected AuthProviderUnavailable, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn valid_token_through_full_pipeline() {
+    let (enc, dec, kid) = {
+        let pair = rsa_key_pair();
+        (pair.0, pair.1, "test-key-1".to_string())
+    };
+    let provider = test_provider();
+    let keys = make_jwks_keys(dec, &kid);
+    let cache = JwksCache::for_test(provider.clone(), keys, Instant::now());
+
+    let claims = default_claims();
+    let token = encode_token(&claims, &enc, &kid);
+
+    let identity = validate_with_refresh(&token, &provider, &cache, &[])
+        .await
+        .expect("validation should succeed");
+    assert_eq!(identity.sub, "user-123");
+    assert_eq!(identity.iss, "https://auth.example.com/");
+}
+
+#[tokio::test]
+async fn unknown_kid_returns_error_after_timeout() {
+    // Pause time so the 5-second timeout in validate_with_refresh completes instantly.
+    tokio::time::pause();
+
+    let (enc, dec, _) = {
+        let pair = rsa_key_pair();
+        (pair.0, pair.1, "test-key-1".to_string())
+    };
+    let provider = test_provider();
+    // Load cache with key "correct-kid" but sign token with "wrong-kid".
+    let keys = make_jwks_keys(dec, "correct-kid");
+    let cache = JwksCache::for_test(provider.clone(), keys, Instant::now());
+
+    let claims = default_claims();
+    let token = encode_token(&claims, &enc, "wrong-kid");
+
+    let err = validate_with_refresh(&token, &provider, &cache, &[])
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, AuthError::UnknownKeyId),
+        "expected UnknownKeyId, got {err:?}"
+    );
+}

--- a/controlplane/src/auth/jwks_cache.rs
+++ b/controlplane/src/auth/jwks_cache.rs
@@ -158,6 +158,26 @@ fn parse_jwks_keys(doc: &JwksDocument) -> Result<Vec<JwksKey>, AuthError> {
     Ok(keys)
 }
 
+// Test-only constructor that doesn't require HTTP.
+#[cfg(test)]
+impl JwksCache {
+    /// Build a cache with pre-loaded keys and a controlled fetch timestamp.
+    ///
+    /// The `http` client is a dummy — `fetch_and_store` should not be called.
+    pub(crate) fn for_test(
+        provider: AuthProvider,
+        keys: Vec<JwksKey>,
+        fetched_at: Instant,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            provider,
+            inner: RwLock::new(CacheInner { keys, fetched_at }),
+            refresh_notify: Arc::new(Notify::new()),
+            http: reqwest::Client::new(),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::types::JwksRawKey;
@@ -197,5 +217,69 @@ mod tests {
 
         let keys = parse_jwks_keys(&doc).unwrap();
         assert!(keys.is_empty());
+    }
+
+    fn test_provider(ttl: u64) -> AuthProvider {
+        AuthProvider {
+            name: "test-provider".into(),
+            issuer: "https://auth.example.com/".into(),
+            audience: "api-gateway".into(),
+            jwks_uri: "http://localhost/.well-known/jwks.json".into(),
+            cache_ttl_seconds: ttl,
+            clock_skew_seconds: 30,
+        }
+    }
+
+    fn test_decoding_key() -> DecodingKey {
+        let pub_pem = include_bytes!("../../../test_fixtures/rsa_public.pem");
+        DecodingKey::from_rsa_pem(pub_pem).expect("test public key")
+    }
+
+    #[tokio::test]
+    async fn fresh_cache_is_not_stale() {
+        let cache = JwksCache::for_test(test_provider(300), vec![], Instant::now());
+        assert!(!cache.is_stale().await);
+    }
+
+    #[tokio::test]
+    async fn old_cache_is_stale() {
+        let old = Instant::now() - Duration::from_secs(3600);
+        let cache = JwksCache::for_test(test_provider(1), vec![], old);
+        // Stale threshold = 1 * 10 = 10s; elapsed ~3600s → stale.
+        assert!(cache.is_stale().await);
+    }
+
+    #[tokio::test]
+    async fn get_keys_returns_loaded_keys() {
+        let key = JwksKey {
+            kid: "k1".into(),
+            decoding_key: test_decoding_key(),
+        };
+        let cache = JwksCache::for_test(test_provider(300), vec![key], Instant::now());
+        let keys = cache.get_keys().await;
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].kid, "k1");
+    }
+
+    #[test]
+    fn provider_name_returns_correct_name() {
+        let cache = JwksCache::for_test(test_provider(300), vec![], Instant::now());
+        assert_eq!(cache.provider_name(), "test-provider");
+    }
+
+    #[tokio::test]
+    async fn trigger_and_wait_notify() {
+        let cache = JwksCache::for_test(test_provider(300), vec![], Instant::now());
+        // trigger_refresh notifies one waiter; spawn a waiter then trigger.
+        let notify = Arc::clone(&cache.refresh_notify);
+        let handle = tokio::spawn(async move {
+            notify.notified().await;
+            true
+        });
+        // Small yield to ensure the spawned task registers the waiter.
+        tokio::task::yield_now().await;
+        cache.trigger_refresh();
+        let got = handle.await.expect("task panicked");
+        assert!(got);
     }
 }

--- a/controlplane/src/auth/mod.rs
+++ b/controlplane/src/auth/mod.rs
@@ -21,6 +21,10 @@ use jwks_cache::JwksCache;
 #[allow(dead_code)]
 use shared::config_types::AuthProvider;
 
+#[cfg(test)]
+#[path = "integration_tests.rs"]
+mod integration_tests;
+
 #[allow(dead_code)]
 /// Validate a token, triggering a JWKS refresh if the `kid` is unknown.
 ///

--- a/controlplane/src/auth/registry.rs
+++ b/controlplane/src/auth/registry.rs
@@ -64,6 +64,11 @@ impl JwksCacheRegistry {
             caches: HashMap::new(),
         })
     }
+
+    /// Create a registry from pre-built caches (no HTTP fetch).
+    pub(crate) fn from_caches_for_test(caches: HashMap<String, Arc<JwksCache>>) -> Self {
+        Self { caches }
+    }
 }
 
 #[cfg(test)]
@@ -82,5 +87,68 @@ mod tests {
             caches: HashMap::new(),
         };
         assert!(registry.get("nonexistent").is_none());
+    }
+
+    fn test_provider(name: &str, ttl: u64) -> shared::config_types::AuthProvider {
+        shared::config_types::AuthProvider {
+            name: name.into(),
+            issuer: "https://auth.example.com/".into(),
+            audience: "api-gateway".into(),
+            jwks_uri: "http://localhost/.well-known/jwks.json".into(),
+            cache_ttl_seconds: ttl,
+            clock_skew_seconds: 30,
+        }
+    }
+
+    #[tokio::test]
+    async fn all_healthy_with_fresh_caches() {
+        let mut caches = HashMap::new();
+        let now = std::time::Instant::now();
+        caches.insert(
+            "a".into(),
+            JwksCache::for_test(test_provider("a", 300), vec![], now),
+        );
+        caches.insert(
+            "b".into(),
+            JwksCache::for_test(test_provider("b", 300), vec![], now),
+        );
+        let reg = JwksCacheRegistry::from_caches_for_test(caches);
+        assert!(reg.all_healthy().await);
+    }
+
+    #[tokio::test]
+    async fn unhealthy_when_any_cache_stale() {
+        let mut caches = HashMap::new();
+        let now = std::time::Instant::now();
+        let old = now - std::time::Duration::from_secs(3600);
+        caches.insert(
+            "fresh".into(),
+            JwksCache::for_test(test_provider("fresh", 300), vec![], now),
+        );
+        caches.insert(
+            "stale".into(),
+            JwksCache::for_test(test_provider("stale", 1), vec![], old),
+        );
+        let reg = JwksCacheRegistry::from_caches_for_test(caches);
+        assert!(!reg.all_healthy().await);
+    }
+
+    #[test]
+    fn get_returns_existing_provider() {
+        let mut caches = HashMap::new();
+        caches.insert(
+            "my-provider".into(),
+            JwksCache::for_test(
+                test_provider("my-provider", 300),
+                vec![],
+                std::time::Instant::now(),
+            ),
+        );
+        let reg = JwksCacheRegistry::from_caches_for_test(caches);
+        assert!(reg.get("my-provider").is_some());
+        assert_eq!(
+            reg.get("my-provider").unwrap().provider_name(),
+            "my-provider"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add 11 new tests covering JWKS cache lifecycle (`is_stale`, `get_keys`, `trigger_refresh`), registry health with mixed stale/fresh caches, and `validate_with_refresh` integration (stale → 503, valid token pipeline, unknown kid timeout)
- Introduce `JwksCache::for_test()` and `JwksCacheRegistry::from_caches_for_test()` constructors for deterministic testing without HTTP
- Enable tokio `test-util` feature in dev-dependencies for time-paused tests

## Test plan
- [x] All 129 tests pass (`cargo test --workspace`)
- [x] Clippy clean (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Formatting clean (`cargo fmt --all -- --check`)
- [x] LOC limits pass (`bash tools/check-loc.sh`)

Closes #16