### PR TITLE
feat: comprehensive rate limit test suite

### DIFF
--- a/controlplane/src/ratelimit/bucket.rs
+++ b/controlplane/src/ratelimit/bucket.rs
@@ -120,4 +120,44 @@ mod tests {
         let key = build_key("rl", "private-api", "sub", "user-123");
         assert_eq!(key, "rl:private-api:sub:user-123");
     }
+
+    #[test]
+    fn capacity_one_single_token() {
+        let mut b = LocalBucket::new(1.0, 0.0);
+        let (allowed, remaining, _) = b.try_consume();
+        assert!(allowed);
+        assert_eq!(remaining, 0);
+        let (allowed, _, retry) = b.try_consume();
+        assert!(!allowed);
+        assert_eq!(retry, u64::MAX);
+    }
+
+    #[test]
+    fn remaining_decrements_each_consume() {
+        let mut b = LocalBucket::new(5.0, 0.0);
+        for expected in (0..5).rev() {
+            let (allowed, remaining, _) = b.try_consume();
+            assert!(allowed);
+            assert_eq!(remaining, expected);
+        }
+        assert!(!b.try_consume().0);
+    }
+
+    #[test]
+    fn retry_after_formula_accuracy() {
+        // refill_rate=2.0 tokens/sec → deficit 1.0 takes 0.5s = 500ms
+        let mut b = LocalBucket::new(1.0, 2.0);
+        b.try_consume(); // consume the only token
+        let (_, _, retry) = b.try_consume();
+        // ceil((1.0 / 2.0) * 1000) = 500
+        assert_eq!(retry, 500);
+    }
+
+    #[test]
+    fn ttl_fractional_rounds_up() {
+        // ttl_seconds(3, 2.0) = ceil((3.0/2.0)*2) = ceil(3.0) = 3
+        assert_eq!(ttl_seconds(3, 2.0), 3);
+        // ttl_seconds(5, 3.0) = ceil((5.0/3.0)*2) = ceil(3.333) = 4
+        assert_eq!(ttl_seconds(5, 3.0), 4);
+    }
 }

--- a/controlplane/src/ratelimit/error.rs
+++ b/controlplane/src/ratelimit/error.rs
@@ -12,3 +12,25 @@ pub(crate) enum RateLimitError {
     #[error("lua response parse error: {0}")]
     LuaResponseParse(String),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_display_messages() {
+        let e = RateLimitError::RedisConnect("refused".into());
+        assert!(e.to_string().contains("refused"));
+
+        let e = RateLimitError::RedisCommand("OOM".into());
+        assert!(e.to_string().contains("OOM"));
+
+        assert!(RateLimitError::Timeout.to_string().contains("timeout"));
+        assert!(RateLimitError::Unavailable
+            .to_string()
+            .contains("unavailable"));
+
+        let e = RateLimitError::LuaResponseParse("bad json".into());
+        assert!(e.to_string().contains("bad json"));
+    }
+}

--- a/controlplane/src/ratelimit/limiter.rs
+++ b/controlplane/src/ratelimit/limiter.rs
@@ -244,6 +244,10 @@ impl RateLimiter {
 }
 
 #[cfg(test)]
+#[path = "limiter_ext_tests.rs"]
+mod ext_tests;
+
+#[cfg(test)]
 mod tests {
     use shared::config_types::SurvivabilityMode;
 

--- a/controlplane/src/ratelimit/limiter_ext_tests.rs
+++ b/controlplane/src/ratelimit/limiter_ext_tests.rs
@@ -1,0 +1,81 @@
+use shared::config_types::SurvivabilityMode;
+
+use super::*;
+
+fn test_config(fail_open: bool, survivability_enabled: bool) -> RateLimitsConfig {
+    RateLimitsConfig {
+        redis_address: "invalid:0".into(),
+        redis_db: 0,
+        redis_key_prefix: "rl".into(),
+        default_timeout_ms: 50,
+        fail_open,
+        survivability_mode: SurvivabilityMode {
+            enabled: survivability_enabled,
+            fallback_capacity: 5,
+            fallback_refill_rate_per_sec: 1.0,
+        },
+    }
+}
+
+#[tokio::test]
+async fn survivability_priority_over_fail_open() {
+    // Both enabled — survivability takes priority.
+    let limiter = RateLimiter::offline_for_test(test_config(true, true));
+    let d = limiter.check("rl:test:ip:10.0.0.1", 10, 1.0).await.unwrap();
+    assert!(d.allowed);
+    assert_eq!(d.mode, RateLimitMode::DegradedLocal);
+}
+
+#[tokio::test]
+async fn different_keys_use_separate_buckets() {
+    let limiter = RateLimiter::offline_for_test(test_config(false, true));
+
+    // Exhaust key-A (capacity 5).
+    for _ in 0..5 {
+        limiter.check("key-a", 10, 1.0).await.unwrap();
+    }
+    let d = limiter.check("key-a", 10, 1.0).await.unwrap();
+    assert!(!d.allowed, "key-a should be exhausted");
+
+    // key-B should still have full capacity.
+    let d = limiter.check("key-b", 10, 1.0).await.unwrap();
+    assert!(d.allowed, "key-b should be independent");
+}
+
+#[tokio::test]
+async fn fail_open_decision_fields() {
+    let limiter = RateLimiter::offline_for_test(test_config(true, false));
+    let d = limiter.check("rl:test:ip:1.2.3.4", 42, 5.0).await.unwrap();
+    assert!(d.allowed);
+    assert_eq!(d.limit, 42);
+    assert_eq!(d.remaining, 42);
+    assert_eq!(d.retry_after_ms, 0);
+    assert_eq!(d.mode, RateLimitMode::FailOpen);
+}
+
+#[tokio::test]
+async fn degraded_remaining_decrements() {
+    let limiter = RateLimiter::offline_for_test(test_config(false, true));
+
+    // Fallback capacity=5, consume 3 → remaining=2.
+    for _ in 0..3 {
+        limiter.check("rl:test:ip:1.1.1.1", 10, 1.0).await.unwrap();
+    }
+    let d = limiter.check("rl:test:ip:1.1.1.1", 10, 1.0).await.unwrap();
+    assert!(d.allowed);
+    assert_eq!(d.remaining, 1); // consumed 4th of 5
+}
+
+#[tokio::test]
+async fn degraded_denied_retry_after_nonzero() {
+    let limiter = RateLimiter::offline_for_test(test_config(false, true));
+
+    // Exhaust all 5 tokens.
+    for _ in 0..5 {
+        limiter.check("rl:test:ip:2.2.2.2", 10, 1.0).await.unwrap();
+    }
+    let d = limiter.check("rl:test:ip:2.2.2.2", 10, 1.0).await.unwrap();
+    assert!(!d.allowed);
+    assert!(d.retry_after_ms > 0, "retry_after should be positive");
+    assert_eq!(d.remaining, 0);
+}

--- a/controlplane/src/ratelimit/lua.rs
+++ b/controlplane/src/ratelimit/lua.rs
@@ -61,4 +61,25 @@ mod tests {
         assert_eq!(resp.remaining_tokens, 0);
         assert_eq!(resp.retry_after_ms, 180);
     }
+
+    #[test]
+    fn parse_response_zero_remaining_allowed() {
+        let json = r#"{"allowed":1,"remaining_tokens":0,"retry_after_ms":0}"#;
+        let resp: LuaResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.allowed, 1);
+        assert_eq!(resp.remaining_tokens, 0);
+    }
+
+    #[test]
+    fn parse_response_large_retry() {
+        let json = r#"{"allowed":0,"remaining_tokens":0,"retry_after_ms":999999}"#;
+        let resp: LuaResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.retry_after_ms, 999_999);
+    }
+
+    #[test]
+    fn parse_invalid_json_fails() {
+        let bad = r#"{"allowed":}"#;
+        assert!(serde_json::from_str::<LuaResponse>(bad).is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- Add 13 new tests covering token bucket boundary conditions (capacity=1, remaining decrements, retry_after formula), Lua response edge cases (zero remaining, large retry, malformed JSON), error Display formatting, and limiter degraded-mode behavior (survivability priority, per-key isolation, decision fields)
- New file `limiter_ext_tests.rs` for extended limiter tests via `#[path]` split
- Total rate limiter tests: 14 → 27

## Test plan
- [x] All 131 tests pass (`cargo test --workspace`)
- [x] Clippy clean (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Formatting clean (`cargo fmt --all -- --check`)
- [x] LOC limits pass (`bash tools/check-loc.sh`)

Closes #17