### PR TITLE
feat: Envoy data plane integration (Epic #5)

### DIFF
--- a/controlplane/src/admin/handlers.rs
+++ b/controlplane/src/admin/handlers.rs
@@ -118,6 +118,29 @@ pub(crate) async fn config_reload(State(state): State<SharedState>) -> impl Into
             cs.last_reload_error = None;
             state.metrics.record_config_reload("success");
 
+            // Regenerate and write Envoy config if path is configured.
+            if let Some(ref envoy_path) = state.envoy_config_path {
+                match config::generate_envoy_config(&cs.config) {
+                    Ok(envoy_yaml) => {
+                        if let Err(e) = std::fs::write(envoy_path, &envoy_yaml) {
+                            tracing::warn!(
+                                path = %envoy_path.display(),
+                                error = %e,
+                                "failed to write envoy config"
+                            );
+                        } else {
+                            tracing::info!(
+                                path = %envoy_path.display(),
+                                "envoy config regenerated"
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "envoy config generation failed on reload");
+                    }
+                }
+            }
+
             tracing::info!(
                 previous_sha256 = %previous_sha,
                 new_sha256 = %new_sha,
@@ -187,6 +210,7 @@ mod tests {
             cfg,
             yaml.as_bytes(),
             PathBuf::from("nonexistent.yaml"),
+            None,
             jwks_registry,
             rate_limiter,
             metrics_registry,

--- a/controlplane/src/admin/state.rs
+++ b/controlplane/src/admin/state.rs
@@ -4,7 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use sha2::{Digest, Sha256};
 use shared::config_types::GatewayConfig;
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, Semaphore};
 
 use crate::auth::JwksCacheRegistry;
 use crate::observability::MetricsRegistry;
@@ -17,12 +17,15 @@ pub(crate) type SharedState = Arc<AppState>;
 pub(crate) struct AppState {
     pub config_state: RwLock<ConfigState>,
     pub config_path: PathBuf,
+    pub envoy_config_path: Option<PathBuf>,
     pub jwks_registry: Arc<JwksCacheRegistry>,
     pub rate_limiter: Arc<RateLimiter>,
     pub metrics: Arc<MetricsRegistry>,
+    pub concurrency_limit: Arc<Semaphore>,
 }
 
 /// Mutable config state protected by a `RwLock`.
+#[derive(Clone)]
 pub(crate) struct ConfigState {
     pub config: GatewayConfig,
     pub sha256: String,
@@ -67,12 +70,19 @@ pub(crate) fn build_state(
     config: GatewayConfig,
     raw_yaml: &[u8],
     config_path: PathBuf,
+    envoy_config_path: Option<PathBuf>,
     jwks_registry: Arc<JwksCacheRegistry>,
     rate_limiter: Arc<RateLimiter>,
     metrics: Arc<MetricsRegistry>,
 ) -> SharedState {
     let sha256 = sha256_hex(raw_yaml);
     let now = now_unix();
+    let max_conc = config
+        .gateway
+        .max_concurrent_requests
+        .map(|n| n as usize)
+        .unwrap_or(Semaphore::MAX_PERMITS);
+    let concurrency_limit = Arc::new(Semaphore::new(max_conc));
 
     Arc::new(AppState {
         config_state: RwLock::new(ConfigState {
@@ -83,9 +93,11 @@ pub(crate) fn build_state(
             last_reload_error: None,
         }),
         config_path,
+        envoy_config_path,
         jwks_registry,
         rate_limiter,
         metrics,
+        concurrency_limit,
     })
 }
 

--- a/controlplane/src/auth/mod.rs
+++ b/controlplane/src/auth/mod.rs
@@ -16,8 +16,7 @@ pub(crate) use registry::JwksCacheRegistry;
 #[allow(dead_code)]
 pub(crate) use types::ValidatedIdentity;
 
-#[allow(dead_code)]
-use jwks_cache::JwksCache;
+pub(crate) use jwks_cache::JwksCache;
 #[allow(dead_code)]
 use shared::config_types::AuthProvider;
 

--- a/controlplane/src/config/envoy_ext_authz.rs
+++ b/controlplane/src/config/envoy_ext_authz.rs
@@ -1,0 +1,99 @@
+use serde_yaml::Value;
+
+use super::envoy_gen::{build_socket_address, val};
+
+/// Build the ext_authz HTTP filter referencing the gateway-manager cluster.
+pub(super) fn build_ext_authz_filter() -> Value {
+    let mut server_uri = serde_yaml::Mapping::new();
+    server_uri.insert(val("uri"), val("http://gateway_manager_extauthz"));
+    server_uri.insert(val("cluster"), val("gateway_manager_extauthz"));
+    server_uri.insert(val("timeout"), val("0.250s"));
+
+    let mut auth_pattern = serde_yaml::Mapping::new();
+    auth_pattern.insert(val("exact"), val("authorization"));
+    let mut host_pattern = serde_yaml::Mapping::new();
+    host_pattern.insert(val("exact"), val("host"));
+    let mut fwd_pattern = serde_yaml::Mapping::new();
+    fwd_pattern.insert(val("prefix"), val("x-forwarded-"));
+
+    let mut allowed_headers = serde_yaml::Mapping::new();
+    allowed_headers.insert(
+        val("patterns"),
+        Value::Sequence(vec![
+            Value::Mapping(auth_pattern),
+            Value::Mapping(host_pattern),
+            Value::Mapping(fwd_pattern),
+        ]),
+    );
+    let mut auth_request = serde_yaml::Mapping::new();
+    auth_request.insert(val("allowed_headers"), Value::Mapping(allowed_headers));
+
+    let mut upstream_pattern = serde_yaml::Mapping::new();
+    upstream_pattern.insert(val("prefix"), val("x-auth-"));
+    let mut rl_pattern = serde_yaml::Mapping::new();
+    rl_pattern.insert(val("prefix"), val("x-ratelimit-"));
+
+    let mut allowed_upstream = serde_yaml::Mapping::new();
+    allowed_upstream.insert(
+        val("patterns"),
+        Value::Sequence(vec![
+            Value::Mapping(upstream_pattern),
+            Value::Mapping(rl_pattern),
+        ]),
+    );
+    let mut auth_response = serde_yaml::Mapping::new();
+    auth_response.insert(
+        val("allowed_upstream_headers"),
+        Value::Mapping(allowed_upstream),
+    );
+
+    let mut http_service = serde_yaml::Mapping::new();
+    http_service.insert(val("server_uri"), Value::Mapping(server_uri));
+    // No path_prefix: Envoy sends the original request path to the check service.
+    http_service.insert(val("authorization_request"), Value::Mapping(auth_request));
+    http_service.insert(val("authorization_response"), Value::Mapping(auth_response));
+
+    let mut typed_config = serde_yaml::Mapping::new();
+    typed_config.insert(
+        val("@type"),
+        val("type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz"),
+    );
+    typed_config.insert(val("transport_api_version"), val("V3"));
+    typed_config.insert(val("http_service"), Value::Mapping(http_service));
+    typed_config.insert(val("failure_mode_allow"), Value::Bool(false));
+
+    let mut filter = serde_yaml::Mapping::new();
+    filter.insert(val("name"), val("envoy.filters.http.ext_authz"));
+    filter.insert(val("typed_config"), Value::Mapping(typed_config));
+
+    Value::Mapping(filter)
+}
+
+/// Build a STATIC cluster for the ext_authz service (gateway-manager).
+pub(super) fn build_ext_authz_cluster(host: &str, port: u16) -> Value {
+    let mut ep_inner = serde_yaml::Mapping::new();
+    ep_inner.insert(val("address"), build_socket_address(host, port));
+    let mut lb_ep = serde_yaml::Mapping::new();
+    lb_ep.insert(val("endpoint"), Value::Mapping(ep_inner));
+
+    let mut endpoint_group = serde_yaml::Mapping::new();
+    endpoint_group.insert(
+        val("lb_endpoints"),
+        Value::Sequence(vec![Value::Mapping(lb_ep)]),
+    );
+
+    let mut load_assignment = serde_yaml::Mapping::new();
+    load_assignment.insert(val("cluster_name"), val("gateway_manager_extauthz"));
+    load_assignment.insert(
+        val("endpoints"),
+        Value::Sequence(vec![Value::Mapping(endpoint_group)]),
+    );
+
+    let mut cluster = serde_yaml::Mapping::new();
+    cluster.insert(val("name"), val("gateway_manager_extauthz"));
+    cluster.insert(val("type"), val("STATIC"));
+    cluster.insert(val("connect_timeout"), val("0.250s"));
+    cluster.insert(val("load_assignment"), Value::Mapping(load_assignment));
+
+    Value::Mapping(cluster)
+}

--- a/controlplane/src/config/envoy_gen.rs
+++ b/controlplane/src/config/envoy_gen.rs
@@ -1,6 +1,8 @@
 use serde_yaml::Value;
 use shared::config_types::{GatewayConfig, RouteConfig, ServiceConfig};
 
+use super::envoy_ext_authz::{build_ext_authz_cluster, build_ext_authz_filter};
+
 /// Errors from Envoy config generation.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum EnvoyGenError {
@@ -15,7 +17,13 @@ pub(crate) enum EnvoyGenError {
 /// The output is a YAML string ready to write to `/etc/envoy/envoy.yaml`.
 pub(crate) fn generate_envoy_config(cfg: &GatewayConfig) -> Result<String, EnvoyGenError> {
     let listener = build_listener(cfg)?;
-    let clusters = build_clusters(&cfg.services)?;
+    let mut clusters = build_clusters(&cfg.services)?;
+
+    // Add ext_authz cluster if configured.
+    if let Some(ref addr) = cfg.gateway.extauthz_address {
+        let (host, port) = parse_endpoint(addr)?;
+        clusters.push(build_ext_authz_cluster(&host, port));
+    }
 
     let root = serde_yaml::to_value(serde_yaml::Mapping::new())?;
     let mut root = match root {
@@ -65,7 +73,12 @@ fn build_listener(cfg: &GatewayConfig) -> Result<Value, EnvoyGenError> {
 
     hcm_typed_config.insert(val("route_config"), Value::Mapping(route_config));
 
-    // Router filter
+    // HTTP filters: ext_authz (optional) → router (terminal).
+    let mut http_filters = Vec::new();
+    if cfg.gateway.extauthz_address.is_some() {
+        http_filters.push(build_ext_authz_filter());
+    }
+
     let mut router_typed = serde_yaml::Mapping::new();
     router_typed.insert(
         val("@type"),
@@ -74,11 +87,9 @@ fn build_listener(cfg: &GatewayConfig) -> Result<Value, EnvoyGenError> {
     let mut router_filter = serde_yaml::Mapping::new();
     router_filter.insert(val("name"), val("envoy.filters.http.router"));
     router_filter.insert(val("typed_config"), Value::Mapping(router_typed));
+    http_filters.push(Value::Mapping(router_filter));
 
-    hcm_typed_config.insert(
-        val("http_filters"),
-        Value::Sequence(vec![Value::Mapping(router_filter)]),
-    );
+    hcm_typed_config.insert(val("http_filters"), Value::Sequence(http_filters));
 
     let mut hcm_filter = serde_yaml::Mapping::new();
     hcm_filter.insert(
@@ -245,7 +256,7 @@ fn build_admin() -> Value {
 }
 
 /// Build an Envoy socket_address block.
-fn build_socket_address(host: &str, port: u16) -> Value {
+pub(super) fn build_socket_address(host: &str, port: u16) -> Value {
     let mut sa = serde_yaml::Mapping::new();
     sa.insert(val("address"), val(host));
     sa.insert(
@@ -292,7 +303,7 @@ fn duration_string(ms: u64) -> String {
 }
 
 /// Shorthand to create a `serde_yaml::Value::String`.
-fn val(s: &str) -> Value {
+pub(super) fn val(s: &str) -> Value {
     Value::String(s.to_owned())
 }
 

--- a/controlplane/src/config/envoy_gen_tests.rs
+++ b/controlplane/src/config/envoy_gen_tests.rs
@@ -193,3 +193,61 @@ fn admin_address_is_localhost() {
     assert_eq!(admin_addr["address"].as_str().unwrap(), "127.0.0.1");
     assert_eq!(admin_addr["port_value"].as_u64().unwrap(), 9901);
 }
+
+#[test]
+fn ext_authz_filter_present_when_configured() {
+    let mut cfg = sample_config();
+    cfg.gateway.extauthz_address = Some("127.0.0.1:10003".into());
+    let envoy = generate_and_parse(&cfg);
+
+    let hcm = &envoy["static_resources"]["listeners"][0]["filter_chains"][0]["filters"][0]
+        ["typed_config"];
+    let filters = hcm["http_filters"].as_sequence().unwrap();
+    assert_eq!(filters.len(), 2, "ext_authz + router");
+    assert_eq!(
+        filters[0]["name"].as_str().unwrap(),
+        "envoy.filters.http.ext_authz"
+    );
+    assert_eq!(
+        filters[1]["name"].as_str().unwrap(),
+        "envoy.filters.http.router"
+    );
+
+    // Verify ext_authz cluster exists.
+    let clusters = envoy["static_resources"]["clusters"].as_sequence().unwrap();
+    let authz_cluster = clusters
+        .iter()
+        .find(|c| c["name"].as_str().unwrap() == "gateway_manager_extauthz")
+        .expect("ext_authz cluster");
+    assert_eq!(authz_cluster["type"].as_str().unwrap(), "STATIC");
+
+    let ep = &authz_cluster["load_assignment"]["endpoints"][0]["lb_endpoints"][0];
+    let sa = &ep["endpoint"]["address"]["socket_address"];
+    assert_eq!(sa["address"].as_str().unwrap(), "127.0.0.1");
+    assert_eq!(sa["port_value"].as_u64().unwrap(), 10003);
+}
+
+#[test]
+fn no_ext_authz_filter_when_not_configured() {
+    let cfg = sample_config();
+    assert!(cfg.gateway.extauthz_address.is_none());
+    let envoy = generate_and_parse(&cfg);
+
+    let hcm = &envoy["static_resources"]["listeners"][0]["filter_chains"][0]["filters"][0]
+        ["typed_config"];
+    let filters = hcm["http_filters"].as_sequence().unwrap();
+    assert_eq!(filters.len(), 1, "only router when no ext_authz");
+    assert_eq!(
+        filters[0]["name"].as_str().unwrap(),
+        "envoy.filters.http.router"
+    );
+
+    // No ext_authz cluster.
+    let clusters = envoy["static_resources"]["clusters"].as_sequence().unwrap();
+    assert!(
+        !clusters
+            .iter()
+            .any(|c| c["name"].as_str().unwrap() == "gateway_manager_extauthz"),
+        "no ext_authz cluster when not configured"
+    );
+}

--- a/controlplane/src/config/mod.rs
+++ b/controlplane/src/config/mod.rs
@@ -2,6 +2,8 @@ mod loader;
 mod validation;
 
 #[allow(dead_code)]
+mod envoy_ext_authz;
+#[allow(dead_code)]
 mod envoy_gen;
 
 #[allow(dead_code)]

--- a/controlplane/src/config/route_matching_tests.rs
+++ b/controlplane/src/config/route_matching_tests.rs
@@ -14,6 +14,8 @@ fn config_with_routes(routes: Vec<RouteConfig>, services: Vec<ServiceConfig>) ->
             idle_timeout_ms: 60000,
             max_request_body_bytes: 10485760,
             trust_forwarded_headers: false,
+            extauthz_address: None,
+            max_concurrent_requests: None,
         },
         auth: AuthConfig { providers: vec![] },
         rate_limits: RateLimitsConfig {

--- a/controlplane/src/config/validation_edge_tests.rs
+++ b/controlplane/src/config/validation_edge_tests.rs
@@ -12,6 +12,8 @@ fn valid_config() -> GatewayConfig {
             idle_timeout_ms: 60000,
             max_request_body_bytes: 10_485_760,
             trust_forwarded_headers: false,
+            extauthz_address: None,
+            max_concurrent_requests: None,
         },
         auth: AuthConfig {
             providers: vec![AuthProvider {

--- a/controlplane/src/config/validation_tests.rs
+++ b/controlplane/src/config/validation_tests.rs
@@ -13,6 +13,8 @@ fn valid_config() -> GatewayConfig {
             idle_timeout_ms: 60000,
             max_request_body_bytes: 10_485_760,
             trust_forwarded_headers: false,
+            extauthz_address: None,
+            max_concurrent_requests: None,
         },
         auth: AuthConfig {
             providers: vec![AuthProvider {

--- a/controlplane/src/extauthz/handler.rs
+++ b/controlplane/src/extauthz/handler.rs
@@ -1,0 +1,245 @@
+use axum::extract::{Request, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use axum::Router;
+
+use shared::config_types::RouteConfig;
+
+use crate::admin::state::SharedState;
+
+/// Build the ext_authz axum router.
+///
+/// Envoy HTTP ext_authz sends the original method and path to the check
+/// service, so we use a fallback handler that matches any request.
+pub(crate) fn router(state: SharedState) -> Router {
+    Router::new().fallback(check).with_state(state)
+}
+
+/// Envoy ext_authz HTTP check handler.
+///
+/// Evaluates auth, rate-limit, and overload for each inbound request.
+/// Returns 200 to allow, or 401/403/429/503 to deny.
+async fn check(State(state): State<SharedState>, req: Request) -> impl IntoResponse {
+    // 1. Overload protection: reject if at max concurrency.
+    let _permit = match state.concurrency_limit.try_acquire() {
+        Ok(p) => p,
+        Err(_) => {
+            state.metrics.record_overload();
+            return overload_response();
+        }
+    };
+
+    state.metrics.inc_inflight();
+    let (parts, _body) = req.into_parts();
+    let result = check_inner(&state, &parts.headers, parts.uri.path()).await;
+    state.metrics.dec_inflight();
+
+    result
+}
+
+/// Inner check logic, separated so inflight gauge is always decremented.
+async fn check_inner(
+    state: &SharedState,
+    headers: &HeaderMap,
+    path: &str,
+) -> axum::response::Response {
+    let host = header_str(headers, "host").unwrap_or("*");
+
+    let cs = state.config_state.read().await;
+    let cfg = &cs.config;
+
+    // 2. Route matching.
+    let route = match match_route(&cfg.routes, host, path) {
+        Some(r) => r,
+        None => return allow_response(HeaderMap::new()),
+    };
+
+    let mut response_headers = HeaderMap::new();
+
+    // 3. Authentication (if required).
+    if route.auth_required {
+        let token = match extract_bearer(headers) {
+            Some(t) => t,
+            None => {
+                state
+                    .metrics
+                    .record_auth_failure(&route.name, "missing_token");
+                return deny_response(StatusCode::UNAUTHORIZED, "missing_token");
+            }
+        };
+
+        let provider_name = route.auth_provider.as_deref().unwrap_or("main");
+        let provider = match cfg.auth.providers.iter().find(|p| p.name == provider_name) {
+            Some(p) => p,
+            None => {
+                state
+                    .metrics
+                    .record_auth_failure(&route.name, "unknown_provider");
+                return deny_response(StatusCode::SERVICE_UNAVAILABLE, "auth_provider_unavailable");
+            }
+        };
+
+        let cache = match state.jwks_registry.get(provider_name) {
+            Some(c) => c,
+            None => {
+                state
+                    .metrics
+                    .record_auth_failure(&route.name, "unknown_provider");
+                return deny_response(StatusCode::SERVICE_UNAVAILABLE, "auth_provider_unavailable");
+            }
+        };
+
+        let required_scopes = route.required_scopes.as_deref().unwrap_or(&[]);
+        match crate::auth::validate_with_refresh(token, provider, cache, required_scopes).await {
+            Ok(identity) => {
+                if let Ok(v) = identity.sub.parse() {
+                    response_headers.insert("x-auth-sub", v);
+                }
+                if let Ok(v) = identity.iss.parse() {
+                    response_headers.insert("x-auth-iss", v);
+                }
+                let scopes = identity.scopes.join(" ");
+                if let Ok(v) = scopes.parse() {
+                    response_headers.insert("x-auth-scopes", v);
+                }
+            }
+            Err(e) => {
+                state
+                    .metrics
+                    .record_auth_failure(&route.name, e.error_code());
+                return deny_response(e.http_status(), e.error_code());
+            }
+        }
+    }
+
+    // 4. Rate limiting.
+    let key_value = if route.rate_limit.key_by == "sub" {
+        response_headers
+            .get("x-auth-sub")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("anonymous")
+            .to_owned()
+    } else {
+        client_ip(headers, cs.config.gateway.trust_forwarded_headers)
+    };
+
+    let bucket_key = crate::ratelimit::build_key(
+        &cfg.rate_limits.redis_key_prefix,
+        &route.name,
+        &route.rate_limit.key_by,
+        &key_value,
+    );
+
+    match state
+        .rate_limiter
+        .check(
+            &bucket_key,
+            route.rate_limit.bucket_capacity,
+            route.rate_limit.refill_rate_per_sec,
+        )
+        .await
+    {
+        Ok(decision) => {
+            let remaining = decision.remaining.to_string();
+            let limit = decision.limit.to_string();
+            if let Ok(v) = remaining.parse() {
+                response_headers.insert("x-ratelimit-remaining", v);
+            }
+            if let Ok(v) = limit.parse() {
+                response_headers.insert("x-ratelimit-limit", v);
+            }
+            if let Ok(v) = decision.mode.as_header_value().parse() {
+                response_headers.insert("x-ratelimit-mode", v);
+            }
+
+            if !decision.allowed {
+                state.metrics.record_rate_limit_denied(&route.name);
+                let retry_after = (decision.retry_after_ms / 1000).max(1).to_string();
+                if let Ok(v) = retry_after.parse() {
+                    response_headers.insert("retry-after", v);
+                }
+                return (StatusCode::TOO_MANY_REQUESTS, response_headers).into_response();
+            }
+
+            match decision.mode {
+                crate::ratelimit::RateLimitMode::DegradedLocal => {
+                    state.metrics.record_rate_limit_degraded(&route.name);
+                }
+                _ => {
+                    state.metrics.record_rate_limit_allowed(&route.name);
+                }
+            }
+        }
+        Err(_) => {
+            state.metrics.record_rate_limit_denied(&route.name);
+            return deny_response(StatusCode::SERVICE_UNAVAILABLE, "rate_limiter_unavailable");
+        }
+    }
+
+    allow_response(response_headers)
+}
+
+/// Match an incoming request to a route by hostname and longest path prefix.
+pub(super) fn match_route<'a>(
+    routes: &'a [RouteConfig],
+    host: &str,
+    path: &str,
+) -> Option<&'a RouteConfig> {
+    routes
+        .iter()
+        .filter(|r| r.hostnames.iter().any(|h| h == "*" || h == host))
+        .filter(|r| path.starts_with(&r.path_prefix))
+        .max_by_key(|r| r.path_prefix.len())
+}
+
+/// Extract the Bearer token from the Authorization header.
+pub(super) fn extract_bearer(headers: &HeaderMap) -> Option<&str> {
+    let value = headers.get("authorization")?.to_str().ok()?;
+    let token = value.strip_prefix("Bearer ")?;
+    if token.is_empty() {
+        return None;
+    }
+    Some(token)
+}
+
+/// Extract the client IP, optionally trusting X-Forwarded-For.
+fn client_ip(headers: &HeaderMap, trust_forwarded: bool) -> String {
+    if trust_forwarded {
+        if let Some(xff) = header_str(headers, "x-forwarded-for") {
+            if let Some(first) = xff.split(',').next() {
+                let ip = first.trim();
+                if !ip.is_empty() {
+                    return ip.to_owned();
+                }
+            }
+        }
+    }
+    header_str(headers, "x-envoy-external-address")
+        .unwrap_or("0.0.0.0")
+        .to_owned()
+}
+
+fn header_str<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
+    headers.get(name)?.to_str().ok()
+}
+
+fn overload_response() -> axum::response::Response {
+    let mut headers = HeaderMap::new();
+    if let Ok(v) = "true".parse() {
+        headers.insert("x-gateway-overloaded", v);
+    }
+    if let Ok(v) = "1".parse() {
+        headers.insert("retry-after", v);
+    }
+    let body = serde_json::json!({"error": "gateway_overloaded"});
+    (StatusCode::SERVICE_UNAVAILABLE, headers, axum::Json(body)).into_response()
+}
+
+fn allow_response(headers: HeaderMap) -> axum::response::Response {
+    (StatusCode::OK, headers).into_response()
+}
+
+fn deny_response(status: StatusCode, error_code: &str) -> axum::response::Response {
+    let body = serde_json::json!({"error": error_code});
+    (status, axum::Json(body)).into_response()
+}

--- a/controlplane/src/extauthz/handler_tests.rs
+++ b/controlplane/src/extauthz/handler_tests.rs
@@ -1,0 +1,216 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{HeaderValue, Request, StatusCode};
+use axum::Router;
+use shared::config_types::RouteConfig;
+use tokio::sync::Semaphore;
+use tower::ServiceExt;
+
+use super::handler::{extract_bearer, match_route, router};
+use crate::admin::state::build_state;
+use crate::config;
+
+// --- Route matching unit tests ---
+
+fn make_route(name: &str, hosts: &[&str], prefix: &str) -> RouteConfig {
+    RouteConfig {
+        name: name.into(),
+        hostnames: hosts.iter().map(|s| s.to_string()).collect(),
+        path_prefix: prefix.into(),
+        methods: vec!["GET".into()],
+        auth_required: false,
+        auth_provider: None,
+        required_scopes: None,
+        rate_limit: shared::config_types::RouteRateLimit {
+            bucket_capacity: 100,
+            refill_rate_per_sec: 10.0,
+            key_by: "ip".into(),
+        },
+        upstream: shared::config_types::UpstreamConfig {
+            service: "backend".into(),
+            request_timeout_ms: 5000,
+            retries: 0,
+        },
+    }
+}
+
+#[test]
+fn match_route_exact_hostname() {
+    let routes = vec![
+        make_route("api", &["api.example.com"], "/v1"),
+        make_route("admin", &["admin.example.com"], "/v1"),
+    ];
+    let matched = match_route(&routes, "api.example.com", "/v1/users");
+    assert_eq!(matched.unwrap().name, "api");
+}
+
+#[test]
+fn match_route_wildcard_hostname() {
+    let routes = vec![make_route("catch-all", &["*"], "/")];
+    let matched = match_route(&routes, "any.host.com", "/some/path");
+    assert_eq!(matched.unwrap().name, "catch-all");
+}
+
+#[test]
+fn match_route_longest_prefix_wins() {
+    let routes = vec![
+        make_route("short", &["*"], "/api"),
+        make_route("long", &["*"], "/api/v2"),
+    ];
+    let matched = match_route(&routes, "example.com", "/api/v2/users");
+    assert_eq!(matched.unwrap().name, "long");
+}
+
+#[test]
+fn match_route_no_match_returns_none() {
+    let routes = vec![make_route("api", &["api.example.com"], "/v1")];
+    assert!(match_route(&routes, "other.com", "/v1/users").is_none());
+    assert!(match_route(&routes, "api.example.com", "/v2/users").is_none());
+}
+
+#[test]
+fn match_route_exact_host_and_wildcard_both_match() {
+    let routes = vec![
+        make_route("specific", &["api.example.com"], "/v1"),
+        make_route("wildcard", &["*"], "/v1"),
+    ];
+    let matched = match_route(&routes, "api.example.com", "/v1/x");
+    assert!(matched.is_some());
+}
+
+// --- Bearer token extraction tests ---
+
+#[test]
+fn extract_bearer_valid() {
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert("authorization", HeaderValue::from_static("Bearer abc123"));
+    assert_eq!(extract_bearer(&headers), Some("abc123"));
+}
+
+#[test]
+fn extract_bearer_missing() {
+    let headers = axum::http::HeaderMap::new();
+    assert_eq!(extract_bearer(&headers), None);
+}
+
+#[test]
+fn extract_bearer_wrong_scheme() {
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert("authorization", HeaderValue::from_static("Basic dXNlcjpw"));
+    assert_eq!(extract_bearer(&headers), None);
+}
+
+#[test]
+fn extract_bearer_empty_token() {
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert("authorization", HeaderValue::from_static("Bearer "));
+    assert_eq!(extract_bearer(&headers), None);
+}
+
+// --- Integration tests ---
+
+fn test_router() -> Router {
+    let yaml = include_str!("../../../examples/configs/gateway-single-node.yaml");
+    let cfg = config::load_config_from_str(yaml).unwrap();
+    let jwks_registry = crate::auth::JwksCacheRegistry::empty_for_test();
+    let rate_limiter = crate::ratelimit::RateLimiter::offline_for_test(cfg.rate_limits.clone());
+    let metrics = Arc::new(crate::observability::MetricsRegistry::new().unwrap());
+    let state = build_state(
+        cfg,
+        yaml.as_bytes(),
+        PathBuf::from("nonexistent.yaml"),
+        None,
+        jwks_registry,
+        rate_limiter,
+        metrics,
+    );
+    router(state)
+}
+
+#[tokio::test]
+async fn check_unmatched_route_returns_200() {
+    let app = test_router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/nonexistent/path")
+                .header("host", "unknown.host.com")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn check_matched_route_allows_or_rate_limits() {
+    let app = test_router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/public/something")
+                .header("host", "example.com")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Rate limiter is offline, so either fail-open (200) or unavailable (503).
+    let status = resp.status();
+    assert!(
+        status == StatusCode::OK
+            || status == StatusCode::SERVICE_UNAVAILABLE
+            || status == StatusCode::TOO_MANY_REQUESTS,
+        "unexpected status: {status}"
+    );
+}
+
+#[tokio::test]
+async fn check_overloaded_returns_503() {
+    let yaml = include_str!("../../../examples/configs/gateway-single-node.yaml");
+    let cfg = config::load_config_from_str(yaml).unwrap();
+    let jwks_registry = crate::auth::JwksCacheRegistry::empty_for_test();
+    let rate_limiter = crate::ratelimit::RateLimiter::offline_for_test(cfg.rate_limits.clone());
+    let metrics = Arc::new(crate::observability::MetricsRegistry::new().unwrap());
+
+    let state = build_state(
+        cfg,
+        yaml.as_bytes(),
+        PathBuf::from("nonexistent.yaml"),
+        None,
+        jwks_registry,
+        rate_limiter,
+        metrics,
+    );
+    // Reconstruct with zero permits to simulate overload.
+    let overloaded_state = Arc::new(crate::admin::state::AppState {
+        config_state: tokio::sync::RwLock::new(state.config_state.read().await.clone()),
+        config_path: state.config_path.clone(),
+        envoy_config_path: None,
+        jwks_registry: Arc::clone(&state.jwks_registry),
+        rate_limiter: Arc::clone(&state.rate_limiter),
+        metrics: Arc::clone(&state.metrics),
+        concurrency_limit: Arc::new(Semaphore::new(0)),
+    });
+
+    let app = router(overloaded_state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/public/test")
+                .header("host", "example.com")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(resp.headers().get("x-gateway-overloaded").unwrap(), "true");
+    assert_eq!(resp.headers().get("retry-after").unwrap(), "1");
+}

--- a/controlplane/src/extauthz/mod.rs
+++ b/controlplane/src/extauthz/mod.rs
@@ -1,0 +1,9 @@
+// External authorization subsystem: HTTP ext_authz service for Envoy.
+// Handles per-request auth validation, rate limiting, and overload protection.
+mod handler;
+
+pub(crate) use handler::router;
+
+#[cfg(test)]
+#[path = "handler_tests.rs"]
+mod handler_tests;

--- a/controlplane/src/main.rs
+++ b/controlplane/src/main.rs
@@ -6,12 +6,13 @@ use tokio::net::TcpListener;
 mod admin;
 mod auth;
 mod config;
+mod extauthz;
 mod observability;
 mod ratelimit;
 
 #[tokio::main]
 async fn main() {
-    // Phase 1: Read config (use eprintln for errors — tracing not yet initialized).
+    // Phase 1: Read config (use eprintln for errors -- tracing not yet initialized).
     let config_path = std::env::var("GATEWAY_CONFIG")
         .map(PathBuf::from)
         .unwrap_or_else(|_| PathBuf::from("configs/gateway.yaml"));
@@ -41,19 +42,21 @@ async fn main() {
     tracing::info!("controlplane starting");
 
     // Phase 2.5: Generate and write Envoy config (if path set).
-    if let Ok(envoy_path) = std::env::var("ENVOY_CONFIG_PATH") {
+    let envoy_config_path = std::env::var("ENVOY_CONFIG_PATH").ok().map(PathBuf::from);
+    if let Some(ref envoy_path) = envoy_config_path {
         let envoy_yaml = config::generate_envoy_config(&cfg).unwrap_or_else(|e| {
             tracing::error!(error = %e, "failed to generate envoy config");
             std::process::exit(1);
         });
-        std::fs::write(&envoy_path, envoy_yaml).unwrap_or_else(|e| {
-            tracing::error!(path = %envoy_path, error = %e, "failed to write envoy config");
+        std::fs::write(envoy_path, envoy_yaml).unwrap_or_else(|e| {
+            tracing::error!(path = %envoy_path.display(), error = %e, "failed to write envoy config");
             std::process::exit(1);
         });
-        tracing::info!(path = %envoy_path, "envoy config written");
+        tracing::info!(path = %envoy_path.display(), "envoy config written");
     }
 
     let admin_addr = cfg.gateway.admin_address.clone();
+    let extauthz_addr = cfg.gateway.extauthz_address.clone();
     tracing::info!(
         version = cfg.version,
         routes = cfg.routes.len(),
@@ -87,22 +90,48 @@ async fn main() {
         cfg,
         &raw_yaml,
         config_path,
+        envoy_config_path,
         jwks_registry,
         rate_limiter,
         metrics,
     );
-    let app = admin::router(state);
 
-    let listener = TcpListener::bind(&admin_addr).await.unwrap_or_else(|e| {
+    // Phase 4: Start servers.
+    let admin_app = admin::router(Arc::clone(&state));
+    let admin_listener = TcpListener::bind(&admin_addr).await.unwrap_or_else(|e| {
         tracing::error!(%admin_addr, "failed to bind admin API: {e}");
         std::process::exit(1);
     });
-
     tracing::info!(%admin_addr, "admin API listening");
-    axum::serve(listener, app).await.unwrap_or_else(|e| {
-        tracing::error!("admin API server error: {e}");
-        std::process::exit(1);
-    });
+
+    if let Some(ref ea_addr) = extauthz_addr {
+        let authz_app = extauthz::router(Arc::clone(&state));
+        let authz_listener = TcpListener::bind(ea_addr).await.unwrap_or_else(|e| {
+            tracing::error!(%ea_addr, "failed to bind ext_authz service: {e}");
+            std::process::exit(1);
+        });
+        tracing::info!(addr = %ea_addr, "ext_authz service listening");
+
+        tokio::select! {
+            res = axum::serve(admin_listener, admin_app) => {
+                if let Err(e) = res {
+                    tracing::error!("admin API server error: {e}");
+                }
+            }
+            res = axum::serve(authz_listener, authz_app) => {
+                if let Err(e) = res {
+                    tracing::error!("ext_authz server error: {e}");
+                }
+            }
+        }
+    } else {
+        axum::serve(admin_listener, admin_app)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::error!("admin API server error: {e}");
+                std::process::exit(1);
+            });
+    }
 
     observability::shutdown_tracing();
 }

--- a/controlplane/src/observability/metrics.rs
+++ b/controlplane/src/observability/metrics.rs
@@ -1,5 +1,6 @@
 use prometheus::{
-    CounterVec, Encoder, HistogramOpts, HistogramVec, IntGauge, Opts, Registry, TextEncoder,
+    CounterVec, Encoder, HistogramOpts, HistogramVec, IntCounter, IntGauge, Opts, Registry,
+    TextEncoder,
 };
 
 /// Errors from the metrics subsystem.
@@ -37,6 +38,7 @@ pub(crate) struct MetricsRegistry {
     upstream_failures_total: CounterVec,
     config_reload_total: CounterVec,
     inflight_requests: IntGauge,
+    overload_total: IntCounter,
 }
 
 /// Histogram buckets for request duration (milliseconds).
@@ -116,6 +118,11 @@ impl MetricsRegistry {
             "Current in-flight HTTP requests",
         )?;
 
+        let overload_total = IntCounter::new(
+            "gateway_overload_total",
+            "Requests rejected due to gateway overload",
+        )?;
+
         registry.register(Box::new(http_requests_total.clone()))?;
         registry.register(Box::new(http_request_duration_ms.clone()))?;
         registry.register(Box::new(auth_failures_total.clone()))?;
@@ -125,6 +132,7 @@ impl MetricsRegistry {
         registry.register(Box::new(upstream_failures_total.clone()))?;
         registry.register(Box::new(config_reload_total.clone()))?;
         registry.register(Box::new(inflight_requests.clone()))?;
+        registry.register(Box::new(overload_total.clone()))?;
 
         Ok(Self {
             registry,
@@ -137,6 +145,7 @@ impl MetricsRegistry {
             upstream_failures_total,
             config_reload_total,
             inflight_requests,
+            overload_total,
         })
     }
 
@@ -199,6 +208,11 @@ impl MetricsRegistry {
     /// Decrement in-flight request gauge.
     pub(crate) fn dec_inflight(&self) {
         self.inflight_requests.dec();
+    }
+
+    /// Record a gateway overload rejection.
+    pub(crate) fn record_overload(&self) {
+        self.overload_total.inc();
     }
 
     /// Encode all metrics as Prometheus text exposition format.

--- a/controlplane/src/ratelimit/mod.rs
+++ b/controlplane/src/ratelimit/mod.rs
@@ -10,5 +10,8 @@ pub(crate) mod limiter;
 mod lua;
 
 #[allow(dead_code, unused_imports)]
+pub(crate) use bucket::build_key;
+#[allow(dead_code, unused_imports)]
 pub(crate) use error::RateLimitError;
-pub(crate) use limiter::RateLimiter;
+#[allow(dead_code, unused_imports)]
+pub(crate) use limiter::{RateDecision, RateLimitMode, RateLimiter};

--- a/docs/adr/0004-http-ext-authz-over-grpc.md
+++ b/docs/adr/0004-http-ext-authz-over-grpc.md
@@ -1,0 +1,40 @@
+# ADR 0004: HTTP ext_authz over gRPC
+
+## Status
+
+Accepted
+
+## Context
+
+Envoy's `ext_authz` filter supports two transport modes for calling an
+external authorization service:
+
+1. **gRPC** -- requires a protobuf service definition, tonic server, and
+   build-time proto compilation.
+2. **HTTP** -- Envoy sends a plain HTTP request with the original request
+   headers and path; the service responds with 200 (allow) or 4xx/5xx (deny).
+
+The gateway-manager already uses axum for the admin API. Adding a second
+axum server on a different port is trivial. Adding a tonic gRPC server
+would require protobuf definitions, `prost-build` compilation, and a
+separate service implementation despite tonic being present in
+`Cargo.toml`.
+
+## Decision
+
+Use Envoy HTTP ext_authz mode with a second axum server on a configurable
+port (default `0.0.0.0:10003`).
+
+Envoy sends the original request method, path, and allowed headers
+(authorization, host, x-forwarded-*) to the ext_authz service. The
+service responds with injected headers (x-auth-sub, x-ratelimit-remaining,
+etc.) that Envoy forwards to the upstream.
+
+## Consequences
+
+- No new dependencies -- reuses axum.
+- Debugging is simpler: `curl` can exercise the ext_authz endpoint.
+- Slight overhead vs binary gRPC, but negligible for auth/rate-limit
+  checks where the bottleneck is Redis/JWKS latency.
+- If gRPC becomes necessary later (e.g., for structured CheckResponse
+  metadata), this ADR can be superseded.

--- a/shared/src/config_types.rs
+++ b/shared/src/config_types.rs
@@ -23,6 +23,14 @@ pub struct GatewayServer {
     pub idle_timeout_ms: u64,
     pub max_request_body_bytes: u64,
     pub trust_forwarded_headers: bool,
+    /// Address for the ext_authz HTTP service (e.g. `"0.0.0.0:10003"`).
+    /// When set, the generated Envoy config includes an ext_authz filter.
+    #[serde(default)]
+    pub extauthz_address: Option<String>,
+    /// Maximum concurrent requests before the gateway returns 503.
+    /// `None` means no limit.
+    #[serde(default)]
+    pub max_concurrent_requests: Option<u64>,
 }
 
 /// Top-level auth configuration.


### PR DESCRIPTION
## Summary

- **#38 ext_authz**: HTTP ext_authz handler on configurable port with per-request auth validation, rate limiting, route matching, and response header injection (x-auth-sub, x-ratelimit-remaining, etc.)
- **#39 config reload signaling**: `POST /config/reload` now regenerates `envoy.yaml` and writes it to disk when `ENVOY_CONFIG_PATH` is set
- **#41 overload circuit breaker**: Semaphore-based concurrency limit returns 503 with `x-gateway-overloaded: true` and `retry-after: 1` when `max_concurrent_requests` is exceeded
- **#42 upstream health checking**: Already implemented via Envoy native health checks in generated config (closed with no code changes)
- **ADR 0004**: Documents HTTP ext_authz over gRPC decision

Closes #38, closes #39, closes #41

## New files
- `controlplane/src/extauthz/` -- ext_authz handler module (mod.rs, handler.rs, handler_tests.rs)
- `controlplane/src/config/envoy_ext_authz.rs` -- ext_authz filter/cluster YAML builders
- `docs/adr/0004-http-ext-authz-over-grpc.md`

## Modified files
- `shared/src/config_types.rs` -- `extauthz_address`, `max_concurrent_requests` fields
- `controlplane/src/admin/state.rs` -- `envoy_config_path`, `concurrency_limit` in AppState
- `controlplane/src/admin/handlers.rs` -- envoy config regeneration on reload
- `controlplane/src/config/envoy_gen.rs` -- ext_authz filter injection
- `controlplane/src/main.rs` -- second server port, envoy path wiring
- `controlplane/src/observability/metrics.rs` -- `gateway_overload_total` counter

## Test plan
- [x] 182 tests pass (14 new: 9 ext_authz handler + 5 route matching/bearer, 2 envoy_gen)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash tools/check-loc.sh`