### PR TITLE
feat: distributed tracing instrumentation

### DIFF
--- a/controlplane/src/admin/state.rs
+++ b/controlplane/src/admin/state.rs
@@ -22,6 +22,7 @@ pub(crate) struct AppState {
     pub rate_limiter: Arc<RateLimiter>,
     pub metrics: Arc<MetricsRegistry>,
     pub concurrency_limit: Arc<Semaphore>,
+    pub tracing_enabled: bool,
 }
 
 /// Mutable config state protected by a `RwLock`.
@@ -83,6 +84,7 @@ pub(crate) fn build_state(
         .map(|n| n as usize)
         .unwrap_or(Semaphore::MAX_PERMITS);
     let concurrency_limit = Arc::new(Semaphore::new(max_conc));
+    let tracing_enabled = config.observability.tracing.enabled;
 
     Arc::new(AppState {
         config_state: RwLock::new(ConfigState {
@@ -98,6 +100,7 @@ pub(crate) fn build_state(
         rate_limiter,
         metrics,
         concurrency_limit,
+        tracing_enabled,
     })
 }
 

--- a/controlplane/src/extauthz/handler.rs
+++ b/controlplane/src/extauthz/handler.rs
@@ -2,6 +2,7 @@ use axum::extract::{Request, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use axum::Router;
+use tracing::Instrument;
 
 use crate::admin::state::SharedState;
 use crate::observability::generate_request_id;
@@ -34,16 +35,46 @@ async fn check(State(state): State<SharedState>, req: Request) -> axum::response
 
     state.metrics.inc_inflight();
     let (parts, _body) = req.into_parts();
-    let result = check_inner(
+    let start = std::time::Instant::now();
+
+    // Create a tracing span (becomes an OTel span when tracing layer is active).
+    let span = tracing::info_span!(
+        "gateway_request",
+        http.method = parts.method.as_str(),
+        http.url = parts.uri.path(),
+        request_id = request_id.as_str(),
+        http.status_code = tracing::field::Empty,
+        route = tracing::field::Empty,
+        upstream_service = tracing::field::Empty,
+        auth_subject = tracing::field::Empty,
+        duration_ms = tracing::field::Empty,
+    );
+
+    // Set inbound traceparent as parent context when tracing is enabled.
+    if state.tracing_enabled {
+        use tracing_opentelemetry::OpenTelemetrySpanExt;
+        span.set_parent(extract_otel_context(&parts.headers));
+    }
+
+    let mut result = check_inner(
         &state,
         &parts.headers,
         parts.method.as_str(),
         parts.uri.path(),
         &request_id,
     )
+    .instrument(span.clone())
     .await;
-    state.metrics.dec_inflight();
 
+    span.record("http.status_code", result.status().as_u16() as i64);
+    span.record("duration_ms", start.elapsed().as_millis() as i64);
+
+    // Inject traceparent into response so Envoy forwards it upstream.
+    if state.tracing_enabled {
+        inject_otel_context(&span, result.headers_mut());
+    }
+
+    state.metrics.dec_inflight();
     result
 }
 
@@ -90,6 +121,9 @@ async fn check_inner(
             return resp;
         }
     };
+
+    tracing::Span::current().record("route", route.name.as_str());
+    tracing::Span::current().record("upstream_service", route.upstream.service.as_str());
 
     // 3. Method check: verify the HTTP method is allowed for this route.
     if !route.methods.iter().any(|m| m.eq_ignore_ascii_case(method)) {
@@ -196,6 +230,7 @@ async fn check_inner(
         let required_scopes = route.required_scopes.as_deref().unwrap_or(&[]);
         match crate::auth::validate_with_refresh(token, provider, cache, required_scopes).await {
             Ok(identity) => {
+                tracing::Span::current().record("auth_subject", identity.sub.as_str());
                 auth_subject = Some(identity.sub.clone());
                 if let Ok(v) = identity.sub.parse() {
                     response_headers.insert("x-auth-sub", v);

--- a/controlplane/src/extauthz/handler_tests.rs
+++ b/controlplane/src/extauthz/handler_tests.rs
@@ -225,6 +225,7 @@ async fn check_overloaded_returns_503() {
         rate_limiter: Arc::clone(&state.rate_limiter),
         metrics: Arc::clone(&state.metrics),
         concurrency_limit: Arc::new(Semaphore::new(0)),
+        tracing_enabled: false,
     });
 
     let app = router(overloaded_state);

--- a/controlplane/src/extauthz/helpers.rs
+++ b/controlplane/src/extauthz/helpers.rs
@@ -217,3 +217,50 @@ pub(super) fn emit_log(
     };
     entry.emit();
 }
+
+// ---------------------------------------------------------------------------
+// OpenTelemetry trace-context propagation helpers
+// ---------------------------------------------------------------------------
+
+/// Adapter for extracting W3C traceparent from [`HeaderMap`].
+pub(super) struct HeaderExtractor<'a>(pub &'a HeaderMap);
+
+impl opentelemetry::propagation::Extractor for HeaderExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|v| v.to_str().ok())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(|k| k.as_str()).collect()
+    }
+}
+
+/// Adapter for injecting W3C traceparent into [`HeaderMap`].
+pub(super) struct HeaderInjector<'a>(pub &'a mut HeaderMap);
+
+impl opentelemetry::propagation::Injector for HeaderInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let (Ok(name), Ok(val)) = (
+            key.parse::<axum::http::HeaderName>(),
+            value.parse::<axum::http::HeaderValue>(),
+        ) {
+            self.0.insert(name, val);
+        }
+    }
+}
+
+/// Extract an OpenTelemetry context from inbound request headers.
+pub(super) fn extract_otel_context(headers: &HeaderMap) -> opentelemetry::Context {
+    opentelemetry::global::get_text_map_propagator(|propagator| {
+        propagator.extract(&HeaderExtractor(headers))
+    })
+}
+
+/// Inject the current span's trace context into response headers.
+pub(super) fn inject_otel_context(span: &tracing::Span, headers: &mut HeaderMap) {
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+    let cx = span.context();
+    opentelemetry::global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&cx, &mut HeaderInjector(headers));
+    });
+}

--- a/controlplane/src/observability/tracing_init.rs
+++ b/controlplane/src/observability/tracing_init.rs
@@ -26,6 +26,11 @@ pub(crate) fn init_tracing(tracing_config: &TracingConfig) -> Result<(), Tracing
     let fmt_layer = tracing_subscriber::fmt::layer();
 
     if tracing_config.enabled {
+        // Register W3C TraceContext propagator for traceparent extraction/injection.
+        opentelemetry::global::set_text_map_propagator(
+            opentelemetry_sdk::propagation::TraceContextPropagator::new(),
+        );
+
         let sampler = opentelemetry_sdk::trace::Sampler::TraceIdRatioBased(
             tracing_config.sample_rate.clamp(0.0, 1.0),
         );


### PR DESCRIPTION
## Summary

- Adds W3C traceparent extraction/injection and per-request span instrumentation to the ext_authz handler
- Registers `TraceContextPropagator` globally when `tracing.enabled: true`
- Creates `gateway_request` span with all spec-required attributes: `http.method`, `http.url`, `http.status_code`, `route`, `upstream_service`, `auth_subject`, `duration_ms`
- Existing `tracing::info!("auth_check")` and `tracing::info!("rate_limit_check")` events automatically become OTel span events inside the instrumented span
- Zero overhead when tracing is disabled — propagation helpers are only invoked conditionally

Closes the last remaining observability spec gaps (distributed tracing section, lines 252–297).

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` — all 179 tests pass
- [x] `bash tools/check-loc.sh` — all files within limits
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)