### PR TITLE
Add bundled core Lua plugins

### DIFF
--- a/controlplane/src/config/envoy_ext_authz.rs
+++ b/controlplane/src/config/envoy_ext_authz.rs
@@ -9,37 +9,21 @@ pub(super) fn build_ext_authz_filter() -> Value {
     server_uri.insert(val("cluster"), val("gateway_manager_extauthz"));
     server_uri.insert(val("timeout"), val("0.250s"));
 
-    let mut auth_pattern = serde_yaml::Mapping::new();
-    auth_pattern.insert(val("exact"), val("authorization"));
-    let mut host_pattern = serde_yaml::Mapping::new();
-    host_pattern.insert(val("exact"), val("host"));
-    let mut fwd_pattern = serde_yaml::Mapping::new();
-    fwd_pattern.insert(val("prefix"), val("x-forwarded-"));
+    let mut any_pattern = serde_yaml::Mapping::new();
+    any_pattern.insert(val("prefix"), val(""));
 
     let mut allowed_headers = serde_yaml::Mapping::new();
     allowed_headers.insert(
         val("patterns"),
-        Value::Sequence(vec![
-            Value::Mapping(auth_pattern),
-            Value::Mapping(host_pattern),
-            Value::Mapping(fwd_pattern),
-        ]),
+        Value::Sequence(vec![Value::Mapping(any_pattern.clone())]),
     );
     let mut auth_request = serde_yaml::Mapping::new();
     auth_request.insert(val("allowed_headers"), Value::Mapping(allowed_headers));
 
-    let mut upstream_pattern = serde_yaml::Mapping::new();
-    upstream_pattern.insert(val("prefix"), val("x-auth-"));
-    let mut rl_pattern = serde_yaml::Mapping::new();
-    rl_pattern.insert(val("prefix"), val("x-ratelimit-"));
-
     let mut allowed_upstream = serde_yaml::Mapping::new();
     allowed_upstream.insert(
         val("patterns"),
-        Value::Sequence(vec![
-            Value::Mapping(upstream_pattern),
-            Value::Mapping(rl_pattern),
-        ]),
+        Value::Sequence(vec![Value::Mapping(any_pattern)]),
     );
     let mut auth_response = serde_yaml::Mapping::new();
     auth_response.insert(

--- a/controlplane/src/config/envoy_gen_tests.rs
+++ b/controlplane/src/config/envoy_gen_tests.rs
@@ -225,6 +225,20 @@ fn ext_authz_filter_present_when_configured() {
     let sa = &ep["endpoint"]["address"]["socket_address"];
     assert_eq!(sa["address"].as_str().unwrap(), "127.0.0.1");
     assert_eq!(sa["port_value"].as_u64().unwrap(), 10003);
+
+    let ext_authz = &filters[0]["typed_config"]["http_service"];
+    assert_eq!(
+        ext_authz["authorization_request"]["allowed_headers"]["patterns"][0]["prefix"]
+            .as_str()
+            .unwrap(),
+        ""
+    );
+    assert_eq!(
+        ext_authz["authorization_response"]["allowed_upstream_headers"]["patterns"][0]["prefix"]
+            .as_str()
+            .unwrap(),
+        ""
+    );
 }
 
 #[test]

--- a/controlplane/src/extauthz/handler.rs
+++ b/controlplane/src/extauthz/handler.rs
@@ -38,6 +38,8 @@ async fn check(State(state): State<SharedState>, req: Request) -> axum::response
     state.metrics.inc_inflight();
     let (parts, _body) = req.into_parts();
     let start = std::time::Instant::now();
+    let request_path = parts.uri.path().to_owned();
+    let request_query = parts.uri.query().map(str::to_owned);
 
     // Create a tracing span (becomes an OTel span when tracing layer is active).
     let span = tracing::info_span!(
@@ -62,7 +64,8 @@ async fn check(State(state): State<SharedState>, req: Request) -> axum::response
         &state,
         &parts.headers,
         parts.method.as_str(),
-        parts.uri.path(),
+        &request_path,
+        request_query.as_deref(),
         &request_id,
     )
     .instrument(span.clone())
@@ -89,15 +92,16 @@ async fn check_inner(
     headers: &HeaderMap,
     method: &str,
     path: &str,
+    query: Option<&str>,
     request_id: &str,
 ) -> axum::response::Response {
     let start = std::time::Instant::now();
     let host = header_str(headers, "host").unwrap_or("*");
-    let remote_addr = client_ip(headers, false);
 
     let cs = state.config_state.read().await;
     let cfg = &cs.config;
     let trust_forwarded = cfg.gateway.trust_forwarded_headers;
+    let remote_addr = client_ip(headers, trust_forwarded);
 
     // 2. Route matching.
     let route = match match_route(&cfg.routes, host, path) {
@@ -127,21 +131,6 @@ async fn check_inner(
     tracing::Span::current().record("route", route.name.as_str());
     tracing::Span::current().record("upstream_service", route.upstream.service.as_str());
 
-    // 3. Method check: verify the HTTP method is allowed for this route.
-    if !route.methods.iter().any(|m| m.eq_ignore_ascii_case(method)) {
-        tracing::debug!(route = %route.name, method, "method not allowed");
-        return method_denied(
-            state,
-            request_id,
-            &remote_addr,
-            host,
-            method,
-            path,
-            route,
-            &start,
-        );
-    }
-
     let mut response_headers = HeaderMap::new();
     let mut auth_subject = None;
     let plugin_continue = match execute_access_plugins(
@@ -152,6 +141,8 @@ async fn check_inner(
             host,
             method,
             path,
+            query,
+            client_ip: &remote_addr,
             request_id,
             remote_addr: &remote_addr,
             start: &start,
@@ -165,6 +156,27 @@ async fn check_inner(
     };
     let plugin_request = plugin_continue.request;
     let plugin_upstream_headers = plugin_continue.upstream_headers;
+
+    // 3. Method check: verify the HTTP method is allowed for this route.
+    if !route.methods.iter().any(|m| m.eq_ignore_ascii_case(method)) {
+        tracing::debug!(route = %route.name, method, "method not allowed");
+        run_plugin_log(
+            state,
+            &plugin_request,
+            StatusCode::METHOD_NOT_ALLOWED.as_u16(),
+        )
+        .await;
+        return method_denied(
+            state,
+            request_id,
+            &remote_addr,
+            host,
+            method,
+            path,
+            route,
+            &start,
+        );
+    }
 
     if let Err(deny) = apply_auth(
         state,

--- a/controlplane/src/extauthz/handler_tests.rs
+++ b/controlplane/src/extauthz/handler_tests.rs
@@ -12,6 +12,7 @@ use super::handler::router;
 use super::helpers::{extract_bearer, match_route, BearerResult};
 use crate::admin::state::build_state;
 use crate::config;
+use crate::plugins::PluginEngine;
 
 // --- Route matching unit tests ---
 
@@ -119,24 +120,40 @@ fn extract_bearer_empty_token() {
 
 // --- Integration tests ---
 
-fn test_router() -> Router {
-    let yaml = include_str!("../../../examples/configs/gateway-single-node.yaml");
-    let cfg = config::load_config_from_str(yaml).unwrap();
+fn plugin_directory() -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../plugins")
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn test_router_for_config(cfg: shared::config_types::GatewayConfig) -> Router {
     let jwks_registry = crate::auth::JwksCacheRegistry::empty_for_test();
     let rate_limiter = crate::ratelimit::RateLimiter::offline_for_test(cfg.rate_limits.clone());
     let metrics = Arc::new(crate::observability::MetricsRegistry::new().unwrap());
+    let plugin_engine = if cfg.plugins.enabled {
+        Some(Arc::new(PluginEngine::from_config(&cfg).unwrap()))
+    } else {
+        None
+    };
     let state = build_state(
         cfg,
-        yaml.as_bytes(),
+        b"test",
         PathBuf::from("nonexistent.yaml"),
         None,
         jwks_registry,
         rate_limiter,
         metrics,
-        None,
+        plugin_engine,
         None,
     );
     router(state)
+}
+
+fn test_router() -> Router {
+    let yaml = include_str!("../../../examples/configs/gateway-single-node.yaml");
+    let cfg = config::load_config_from_str(yaml).unwrap();
+    test_router_for_config(cfg)
 }
 
 #[tokio::test]
@@ -251,4 +268,81 @@ async fn check_overloaded_returns_503() {
     assert_eq!(resp.headers().get("x-gateway-overloaded").unwrap(), "true");
     assert_eq!(resp.headers().get("retry-after").unwrap(), "1");
     assert!(resp.headers().get("x-request-id").is_some());
+}
+
+#[tokio::test]
+async fn plugins_can_short_circuit_options_before_method_check() {
+    let yaml = include_str!("../../../examples/configs/gateway-single-node.yaml");
+    let mut cfg = config::load_config_from_str(yaml).unwrap();
+    cfg.plugins.enabled = true;
+    cfg.plugins.directory = plugin_directory();
+    cfg.routes[0].plugins = vec![shared::config_types::PluginInstance {
+        name: "cors".to_owned(),
+        enabled: true,
+        fail_mode: "closed".to_owned(),
+        config: serde_yaml::from_str(
+            r#"
+origins: ["https://app.example.com"]
+methods: ["GET", "POST"]
+headers: ["authorization"]
+"#,
+        )
+        .unwrap(),
+    }];
+
+    let app = test_router_for_config(cfg);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("OPTIONS")
+                .uri("/public/something")
+                .header("host", "example.com")
+                .header("origin", "https://app.example.com")
+                .header("access-control-request-method", "POST")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert_eq!(
+        resp.headers().get("access-control-allow-origin").unwrap(),
+        "https://app.example.com"
+    );
+}
+
+#[tokio::test]
+async fn api_key_plugin_rejects_requests_without_credentials() {
+    let yaml = include_str!("../../../examples/configs/gateway-single-node.yaml");
+    let mut cfg = config::load_config_from_str(yaml).unwrap();
+    cfg.plugins.enabled = true;
+    cfg.plugins.directory = plugin_directory();
+    cfg.routes[0].plugins = vec![shared::config_types::PluginInstance {
+        name: "api-key-auth".to_owned(),
+        enabled: true,
+        fail_mode: "closed".to_owned(),
+        config: serde_yaml::from_str(
+            r#"
+keys:
+  - key: "secret"
+    consumer: "consumer-123"
+"#,
+        )
+        .unwrap(),
+    }];
+
+    let app = test_router_for_config(cfg);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/public/something")
+                .header("host", "example.com")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }

--- a/controlplane/src/extauthz/plugin_step.rs
+++ b/controlplane/src/extauthz/plugin_step.rs
@@ -17,6 +17,8 @@ pub(super) struct PluginExecutionMeta<'a> {
     pub host: &'a str,
     pub method: &'a str,
     pub path: &'a str,
+    pub query: Option<&'a str>,
+    pub client_ip: &'a str,
     pub request_id: &'a str,
     pub remote_addr: &'a str,
     pub start: &'a std::time::Instant,
@@ -33,6 +35,7 @@ pub(super) async fn execute_access_plugins<'a>(
         host: meta.host,
         method: meta.method,
         path: meta.path,
+        client_ip: meta.client_ip,
         headers: meta
             .headers
             .iter()
@@ -43,6 +46,14 @@ pub(super) async fn execute_access_plugins<'a>(
                     .map(|value| (name.as_str().to_owned(), value.to_owned()))
             })
             .collect(),
+        query_params: meta
+            .query
+            .map(|query| {
+                url::form_urlencoded::parse(query.as_bytes())
+                    .map(|(name, value)| (name.into_owned(), value.into_owned()))
+                    .collect()
+            })
+            .unwrap_or_default(),
     };
 
     let Some(plugin_engine) = state.plugin_engine.as_ref() else {

--- a/controlplane/src/plugins/executor.rs
+++ b/controlplane/src/plugins/executor.rs
@@ -34,7 +34,7 @@ impl PluginEngine {
                 name: "ctx".to_owned(),
                 reason: e.to_string(),
             })?;
-            let runtime_state = Rc::new(RefCell::new(RuntimeState::new()));
+            let runtime_state = Rc::new(RefCell::new(RuntimeState::new(request)));
 
             for binding in &bindings {
                 if started.elapsed().as_millis() as u64 > limits.chain_timeout_ms {
@@ -113,7 +113,7 @@ impl PluginEngine {
                 name: "ctx".to_owned(),
                 reason: e.to_string(),
             })?;
-            let runtime_state = Rc::new(RefCell::new(RuntimeState::new()));
+            let runtime_state = Rc::new(RefCell::new(RuntimeState::new(request)));
 
             for binding in &bindings {
                 let _ = run_phase(
@@ -262,3 +262,7 @@ fn plugin_instance(vm: &mut ThreadLocalVm, binding: &PluginBinding) -> Result<Ta
     vm.insert_registry_key(&binding.id, key);
     Ok(instance)
 }
+
+#[cfg(test)]
+#[path = "executor_tests.rs"]
+mod tests;

--- a/controlplane/src/plugins/executor_tests.rs
+++ b/controlplane/src/plugins/executor_tests.rs
@@ -1,0 +1,299 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde_json::json;
+use shared::config_types::PluginLimits;
+
+use super::*;
+use crate::plugins::types::{PluginBinding, PluginChain, PluginRuntime};
+
+fn test_engine(name: &str, source: &str, config: serde_json::Value) -> PluginEngine {
+    let runtime = PluginRuntime {
+        generation: 1,
+        limits: PluginLimits::default(),
+        chains: HashMap::from([(
+            "route".to_owned(),
+            PluginChain {
+                bindings: vec![PluginBinding {
+                    id: format!("route:{name}"),
+                    name: name.to_owned(),
+                    priority: 100,
+                    version: "0.1.0".to_owned(),
+                    fail_open: false,
+                    source: Arc::new(source.to_owned()),
+                    config,
+                }],
+            },
+        )]),
+    };
+    PluginEngine::new(runtime)
+}
+
+fn request(
+    method: &'static str,
+    path: &'static str,
+    client_ip: &'static str,
+    headers: &[(&str, &str)],
+    query_params: &[(&str, &str)],
+) -> crate::plugins::PluginRequest<'static> {
+    crate::plugins::PluginRequest {
+        route_name: "route",
+        host: "example.com",
+        method,
+        path,
+        client_ip,
+        headers: headers
+            .iter()
+            .map(|(name, value)| ((*name).to_owned(), (*value).to_owned()))
+            .collect(),
+        query_params: query_params
+            .iter()
+            .map(|(name, value)| ((*name).to_owned(), (*value).to_owned()))
+            .collect(),
+    }
+}
+
+#[tokio::test]
+async fn api_key_auth_allows_query_credentials_and_strips_them_from_upstream_path() {
+    let engine = test_engine(
+        "api-key-auth",
+        include_str!("../../../plugins/api-key-auth.lua"),
+        json!({
+            "query_name": "apikey",
+            "hide_credentials": true,
+            "keys": [
+                { "key": "secret", "consumer": "consumer-123" }
+            ]
+        }),
+    );
+
+    let result = engine
+        .execute_access(&request(
+            "GET",
+            "/public/echo",
+            "10.0.0.4",
+            &[("host", "example.com")],
+            &[("apikey", "secret"), ("page", "2")],
+        ))
+        .await
+        .unwrap();
+
+    match result {
+        PluginAccessResult::Continue {
+            upstream_headers, ..
+        } => {
+            assert_eq!(
+                upstream_headers.get("x-consumer-id"),
+                Some(&"consumer-123".to_owned())
+            );
+            assert_eq!(
+                upstream_headers.get(":path"),
+                Some(&"/public/echo?page=2".to_owned())
+            );
+        }
+        other => panic!("expected continue result, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn basic_auth_accepts_valid_credentials() {
+    let engine = test_engine(
+        "basic-auth",
+        include_str!("../../../plugins/basic-auth.lua"),
+        json!({
+            "credentials": [
+                { "username": "user", "password": "pass", "consumer": "consumer-42" }
+            ]
+        }),
+    );
+
+    let result = engine
+        .execute_access(&request(
+            "GET",
+            "/private",
+            "10.0.0.5",
+            &[("authorization", "Basic dXNlcjpwYXNz")],
+            &[],
+        ))
+        .await
+        .unwrap();
+
+    match result {
+        PluginAccessResult::Continue {
+            upstream_headers, ..
+        } => {
+            assert_eq!(
+                upstream_headers.get("x-consumer-id"),
+                Some(&"consumer-42".to_owned())
+            );
+            assert_eq!(
+                upstream_headers.get("x-consumer-username"),
+                Some(&"user".to_owned())
+            );
+        }
+        other => panic!("expected continue result, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn cors_short_circuits_preflight_requests() {
+    let engine = test_engine(
+        "cors",
+        include_str!("../../../plugins/cors.lua"),
+        json!({
+            "origins": ["https://app.example.com"],
+            "methods": ["GET", "POST"],
+            "headers": ["authorization", "content-type"],
+            "max_age": 300,
+            "credentials": true
+        }),
+    );
+
+    let result = engine
+        .execute_access(&request(
+            "OPTIONS",
+            "/public/echo",
+            "10.0.0.6",
+            &[
+                ("origin", "https://app.example.com"),
+                ("access-control-request-method", "POST"),
+            ],
+            &[],
+        ))
+        .await
+        .unwrap();
+
+    match result {
+        PluginAccessResult::ShortCircuit {
+            status, headers, ..
+        } => {
+            assert_eq!(status, 204);
+            assert_eq!(
+                headers.get("access-control-allow-origin"),
+                Some(&"https://app.example.com".to_owned())
+            );
+            assert_eq!(
+                headers.get("access-control-allow-methods"),
+                Some(&"GET, POST".to_owned())
+            );
+            assert_eq!(
+                headers.get("access-control-max-age"),
+                Some(&"300".to_owned())
+            );
+        }
+        other => panic!("expected short circuit result, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn ip_restriction_blocks_denied_cidr_ranges() {
+    let engine = test_engine(
+        "ip-restriction",
+        include_str!("../../../plugins/ip-restriction.lua"),
+        json!({
+            "deny": ["10.0.0.0/24"],
+            "message": "blocked"
+        }),
+    );
+
+    let result = engine
+        .execute_access(&request("GET", "/private", "10.0.0.9", &[], &[]))
+        .await
+        .unwrap();
+
+    match result {
+        PluginAccessResult::ShortCircuit {
+            status,
+            body,
+            headers,
+            ..
+        } => {
+            assert_eq!(status, 403);
+            assert_eq!(
+                headers.get("content-type"),
+                Some(&"application/json".to_owned())
+            );
+            assert!(body.unwrap_or_default().contains("blocked"));
+        }
+        other => panic!("expected short circuit result, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn request_size_limiting_rejects_large_payloads() {
+    let engine = test_engine(
+        "request-size-limiting",
+        include_str!("../../../plugins/request-size-limiting.lua"),
+        json!({
+            "max_bytes": 8
+        }),
+    );
+
+    let result = engine
+        .execute_access(&request(
+            "POST",
+            "/upload",
+            "10.0.0.10",
+            &[("content-length", "32")],
+            &[],
+        ))
+        .await
+        .unwrap();
+
+    match result {
+        PluginAccessResult::ShortCircuit { status, body, .. } => {
+            assert_eq!(status, 413);
+            assert!(body.unwrap_or_default().contains("payload_too_large"));
+        }
+        other => panic!("expected short circuit result, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn request_transformer_rewrites_path_headers_and_query_params() {
+    let engine = test_engine(
+        "request-transformer",
+        include_str!("../../../plugins/request-transformer.lua"),
+        json!({
+            "add_headers": {
+                "x-added": "true"
+            },
+            "rename_headers": {
+                "x-request-id": "x-original-request-id"
+            },
+            "set_query_params": {
+                "version": "v2"
+            },
+            "remove_query_params": ["debug"],
+            "rewrite_path": "/rewritten/resource"
+        }),
+    );
+
+    let result = engine
+        .execute_access(&request(
+            "GET",
+            "/public/resource",
+            "10.0.0.11",
+            &[("x-request-id", "req-123")],
+            &[("debug", "1"), ("page", "3")],
+        ))
+        .await
+        .unwrap();
+
+    match result {
+        PluginAccessResult::Continue {
+            upstream_headers, ..
+        } => {
+            assert_eq!(upstream_headers.get("x-added"), Some(&"true".to_owned()));
+            assert_eq!(
+                upstream_headers.get("x-original-request-id"),
+                Some(&"req-123".to_owned())
+            );
+            assert_eq!(
+                upstream_headers.get(":path"),
+                Some(&"/rewritten/resource?page=3&version=v2".to_owned())
+            );
+        }
+        other => panic!("expected continue result, got {other:?}"),
+    }
+}

--- a/controlplane/src/plugins/registry.rs
+++ b/controlplane/src/plugins/registry.rs
@@ -185,3 +185,7 @@ fn validate_schema(meta: &PluginMeta, instance: &PluginInstance) -> Result<(), P
     }
     Ok(())
 }
+
+#[cfg(test)]
+#[path = "registry_tests.rs"]
+mod tests;

--- a/controlplane/src/plugins/registry_tests.rs
+++ b/controlplane/src/plugins/registry_tests.rs
@@ -1,0 +1,86 @@
+use std::path::PathBuf;
+
+use serde_yaml::Value as YamlValue;
+use shared::config_types::PluginInstance;
+
+use super::*;
+
+fn plugin_dir() -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../plugins")
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn sample_config() -> shared::config_types::GatewayConfig {
+    crate::config::load_config_from_str(include_str!(
+        "../../../examples/configs/gateway-single-node.yaml"
+    ))
+    .unwrap()
+}
+
+fn plugin_instance(name: &str, config: YamlValue) -> PluginInstance {
+    PluginInstance {
+        name: name.to_owned(),
+        enabled: true,
+        fail_mode: "closed".to_owned(),
+        config,
+    }
+}
+
+#[test]
+fn build_runtime_loads_bundled_plugins_in_priority_order() {
+    let mut config = sample_config();
+    config.plugins.enabled = true;
+    config.plugins.directory = plugin_dir();
+    config.routes[0].plugins = vec![
+        plugin_instance(
+            "request-transformer",
+            serde_yaml::from_str(
+                r#"
+add_headers:
+  x-added: "true"
+"#,
+            )
+            .unwrap(),
+        ),
+        plugin_instance(
+            "cors",
+            serde_yaml::from_str(
+                r#"
+origins: ["*"]
+methods: ["GET", "POST"]
+"#,
+            )
+            .unwrap(),
+        ),
+    ];
+
+    let runtime = build_runtime(&config, 7).unwrap();
+    let bindings = &runtime.chains["public-echo"].bindings;
+
+    assert_eq!(bindings.len(), 2);
+    assert_eq!(bindings[0].name, "cors");
+    assert_eq!(bindings[1].name, "request-transformer");
+    assert_eq!(runtime.generation, 7);
+}
+
+#[test]
+fn build_runtime_rejects_invalid_bundled_plugin_config() {
+    let mut config = sample_config();
+    config.plugins.enabled = true;
+    config.plugins.directory = plugin_dir();
+    config.routes[0].plugins = vec![plugin_instance(
+        "request-size-limiting",
+        serde_yaml::from_str("{}").unwrap(),
+    )];
+
+    let error = build_runtime(&config, 1).unwrap_err();
+    match error {
+        PluginError::SchemaValidation { name, reason } => {
+            assert_eq!(name, "request-size-limiting");
+            assert!(reason.contains("max_bytes"));
+        }
+        other => panic!("expected schema validation error, got {other:?}"),
+    }
+}

--- a/controlplane/src/plugins/sdk.rs
+++ b/controlplane/src/plugins/sdk.rs
@@ -13,20 +13,80 @@ pub(crate) struct RuntimeState {
     pub upstream_headers: HashMap<String, String>,
     pub response_headers: HashMap<String, String>,
     pub short_circuit: Option<PluginExit>,
+    path: String,
+    query_params: Vec<(String, String)>,
+    path_dirty: bool,
 }
 
 impl RuntimeState {
-    pub fn new() -> Self {
+    pub fn new(request: &PluginRequest<'_>) -> Self {
         Self {
             upstream_headers: HashMap::new(),
             response_headers: HashMap::new(),
             short_circuit: None,
+            path: request.path.to_owned(),
+            query_params: request.query_params.clone(),
+            path_dirty: false,
         }
+    }
+
+    fn set_path(&mut self, path: String) {
+        if let Some((next_path, raw_query)) = path.split_once('?') {
+            self.path = normalize_path(next_path);
+            self.query_params = parse_query_params(raw_query);
+        } else {
+            self.path = normalize_path(&path);
+        }
+        self.path_dirty = true;
+        self.sync_path_header();
+    }
+
+    fn set_query_param(&mut self, name: String, value: String) {
+        if let Some((_, current_value)) = self
+            .query_params
+            .iter_mut()
+            .find(|(current_name, _)| current_name == &name)
+        {
+            *current_value = value;
+        } else {
+            self.query_params.push((name, value));
+        }
+        self.path_dirty = true;
+        self.sync_path_header();
+    }
+
+    fn remove_query_param(&mut self, name: &str) {
+        self.query_params
+            .retain(|(current_name, _)| current_name != name);
+        self.path_dirty = true;
+        self.sync_path_header();
+    }
+
+    fn sync_path_header(&mut self) {
+        if !self.path_dirty {
+            self.upstream_headers.remove(":path");
+            return;
+        }
+
+        let mut rewritten = self.path.clone();
+        if !self.query_params.is_empty() {
+            let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+            for (name, value) in &self.query_params {
+                serializer.append_pair(name, value);
+            }
+            rewritten.push('?');
+            rewritten.push_str(&serializer.finish());
+        }
+        self.upstream_headers.insert(":path".to_owned(), rewritten);
     }
 }
 
 pub(crate) fn is_exit_error(error: &mlua::Error) -> bool {
-    matches!(error, mlua::Error::RuntimeError(message) if message == EXIT_SENTINEL)
+    match error {
+        mlua::Error::RuntimeError(message) => message.contains(EXIT_SENTINEL),
+        mlua::Error::CallbackError { cause, .. } => is_exit_error(cause),
+        _ => false,
+    }
 }
 
 pub(crate) fn install_gateway(
@@ -74,10 +134,25 @@ fn build_request_api(lua: &Lua, request: &PluginRequest<'_>) -> LuaResult<Table>
         "get_path",
         lua.create_function(move |_, ()| Ok(path.clone()))?,
     )?;
+    let query_params = request.query_params.clone();
+    table.set(
+        "get_query",
+        lua.create_function(move |_, name: String| {
+            Ok(query_params
+                .iter()
+                .find(|(key, _)| key == &name)
+                .map(|(_, value)| value.clone()))
+        })?,
+    )?;
     let host = request.host.to_owned();
     table.set(
         "get_host",
         lua.create_function(move |_, ()| Ok(host.clone()))?,
+    )?;
+    let client_ip = request.client_ip.to_owned();
+    table.set(
+        "get_client_ip",
+        lua.create_function(move |_, ()| Ok(client_ip.clone()))?,
     )?;
     Ok(table)
 }
@@ -116,6 +191,7 @@ fn build_response_api(
 fn build_service_api(lua: &Lua, runtime: Rc<RefCell<RuntimeState>>) -> LuaResult<Table> {
     let service = lua.create_table()?;
     let request = lua.create_table()?;
+    let runtime_for_headers = runtime.clone();
     request.set(
         "set_header",
         lua.create_function(move |_, (name, value): (String, String)| {
@@ -128,7 +204,35 @@ fn build_service_api(lua: &Lua, runtime: Rc<RefCell<RuntimeState>>) -> LuaResult
                     "header '{name}' is reserved and cannot be set by plugins"
                 )));
             }
-            runtime.borrow_mut().upstream_headers.insert(lower, value);
+            runtime_for_headers
+                .borrow_mut()
+                .upstream_headers
+                .insert(lower, value);
+            Ok(())
+        })?,
+    )?;
+    let runtime_for_path = runtime.clone();
+    request.set(
+        "set_path",
+        lua.create_function(move |_, path: String| {
+            runtime_for_path.borrow_mut().set_path(path);
+            Ok(())
+        })?,
+    )?;
+    let runtime_for_set_query = runtime.clone();
+    request.set(
+        "set_query_param",
+        lua.create_function(move |_, (name, value): (String, String)| {
+            runtime_for_set_query
+                .borrow_mut()
+                .set_query_param(name, value);
+            Ok(())
+        })?,
+    )?;
+    request.set(
+        "remove_query_param",
+        lua.create_function(move |_, name: String| {
+            runtime.borrow_mut().remove_query_param(&name);
             Ok(())
         })?,
     )?;
@@ -187,10 +291,30 @@ fn build_plugin_api(lua: &Lua, binding: &PluginBinding) -> LuaResult<Table> {
         "get_version",
         lua.create_function(move |_, ()| Ok(version.clone()))?,
     )?;
-    table.set("get_config", lua.to_value(&binding.config)?)?;
+    let config = lua.to_value(&binding.config)?;
+    table.set(
+        "get_config",
+        lua.create_function(move |_, ()| Ok(config.clone()))?,
+    )?;
     Ok(table)
 }
 
 pub(crate) fn clear_gateway(lua: &Lua) -> LuaResult<()> {
     lua.globals().set("gateway", Value::Nil)
+}
+
+fn normalize_path(path: &str) -> String {
+    if path.is_empty() {
+        "/".to_owned()
+    } else if path.starts_with('/') {
+        path.to_owned()
+    } else {
+        format!("/{path}")
+    }
+}
+
+fn parse_query_params(query: &str) -> Vec<(String, String)> {
+    url::form_urlencoded::parse(query.as_bytes())
+        .map(|(name, value)| (name.into_owned(), value.into_owned()))
+        .collect()
 }

--- a/controlplane/src/plugins/types.rs
+++ b/controlplane/src/plugins/types.rs
@@ -48,7 +48,9 @@ pub(crate) struct PluginRequest<'a> {
     pub host: &'a str,
     pub method: &'a str,
     pub path: &'a str,
+    pub client_ip: &'a str,
     pub headers: Vec<(String, String)>,
+    pub query_params: Vec<(String, String)>,
 }
 
 /// Result of the access phase.

--- a/plugins/api-key-auth.lua
+++ b/plugins/api-key-auth.lua
@@ -1,0 +1,70 @@
+local cjson = require("cjson")
+
+local plugin = {
+  VERSION = "0.1.0",
+  PRIORITY = 500,
+  SCHEMA = {
+    type = "object",
+    additionalProperties = false,
+    properties = {
+      header_name = { type = "string" },
+      query_name = { type = "string" },
+      hide_credentials = { type = "boolean" },
+      keys = {
+        type = "array",
+        minItems = 1,
+        items = {
+          type = "object",
+          additionalProperties = false,
+          properties = {
+            key = { type = "string" },
+            consumer = { type = "string" },
+          },
+          required = { "key", "consumer" },
+        },
+      },
+    },
+    required = { "keys" },
+  },
+}
+
+local function config_value(config, key, fallback)
+  if config[key] == nil then
+    return fallback
+  end
+  return config[key]
+end
+
+function plugin:access(_ctx)
+  local config = gateway.plugin.get_config()
+  local header_name = config_value(config, "header_name", "x-api-key")
+  local query_name = config_value(config, "query_name", "apikey")
+  local hide_credentials = config_value(config, "hide_credentials", false)
+
+  local key = gateway.request.get_header(header_name)
+  local source = "header"
+  if not key then
+    key = gateway.request.get_query(query_name)
+    source = "query"
+  end
+
+  if not key then
+    gateway.response.set_header("content-type", "application/json")
+    gateway.response.exit(401, cjson.encode({ error = "missing_api_key" }))
+  end
+
+  for _, entry in ipairs(config.keys) do
+    if entry.key == key then
+      gateway.service.request.set_header("x-consumer-id", entry.consumer)
+      if hide_credentials and source == "query" then
+        gateway.service.request.remove_query_param(query_name)
+      end
+      return
+    end
+  end
+
+  gateway.response.set_header("content-type", "application/json")
+  gateway.response.exit(401, cjson.encode({ error = "invalid_api_key" }))
+end
+
+return plugin

--- a/plugins/basic-auth.lua
+++ b/plugins/basic-auth.lua
@@ -1,0 +1,101 @@
+local cjson = require("cjson")
+
+local plugin = {
+  VERSION = "0.1.0",
+  PRIORITY = 550,
+  SCHEMA = {
+    type = "object",
+    additionalProperties = false,
+    properties = {
+      realm = { type = "string" },
+      credentials = {
+        type = "array",
+        minItems = 1,
+        items = {
+          type = "object",
+          additionalProperties = false,
+          properties = {
+            username = { type = "string" },
+            password = { type = "string" },
+            consumer = { type = "string" },
+          },
+          required = { "username", "password", "consumer" },
+        },
+      },
+    },
+    required = { "credentials" },
+  },
+}
+
+local BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+local function decode_base64(input)
+  local sanitized = input:gsub("[^" .. BASE64_ALPHABET .. "=]", "")
+  local bit_pattern = sanitized:gsub(".", function(char)
+    if char == "=" then
+      return ""
+    end
+    local index = BASE64_ALPHABET:find(char, 1, true)
+    if not index then
+      return ""
+    end
+    local value = index - 1
+    local bits = ""
+    for _ = 1, 6 do
+      bits = tostring(value % 2) .. bits
+      value = math.floor(value / 2)
+    end
+    return bits
+  end)
+
+  return bit_pattern:gsub("%d%d%d?%d?%d?%d?%d?%d?", function(chunk)
+    if #chunk ~= 8 then
+      return ""
+    end
+    local value = 0
+    for i = 1, 8 do
+      value = (value * 2) + tonumber(chunk:sub(i, i))
+    end
+    return string.char(value)
+  end)
+end
+
+function plugin:access(_ctx)
+  local config = gateway.plugin.get_config()
+  local realm = config.realm or "OpenApiGateway"
+  local authorization = gateway.request.get_header("authorization")
+  if not authorization then
+    gateway.response.set_header("www-authenticate", 'Basic realm="' .. realm .. '"')
+    gateway.response.set_header("content-type", "application/json")
+    gateway.response.exit(401, cjson.encode({ error = "missing_basic_auth" }))
+  end
+
+  local encoded = authorization:match("^Basic%s+(.+)$")
+  if not encoded then
+    gateway.response.set_header("www-authenticate", 'Basic realm="' .. realm .. '"')
+    gateway.response.set_header("content-type", "application/json")
+    gateway.response.exit(401, cjson.encode({ error = "invalid_basic_auth" }))
+  end
+
+  local decoded = decode_base64(encoded)
+  local username, password = decoded:match("^([^:]+):(.*)$")
+  if not username then
+    gateway.response.set_header("www-authenticate", 'Basic realm="' .. realm .. '"')
+    gateway.response.set_header("content-type", "application/json")
+    gateway.response.exit(401, cjson.encode({ error = "invalid_basic_auth" }))
+  end
+
+  for _, entry in ipairs(config.credentials) do
+    if entry.username == username and entry.password == password then
+      gateway.service.request.set_header("x-consumer-id", entry.consumer)
+      gateway.service.request.set_header("x-consumer-username", username)
+      return
+    end
+  end
+
+  gateway.response.set_header("www-authenticate", 'Basic realm="' .. realm .. '"')
+  gateway.response.set_header("content-type", "application/json")
+  gateway.response.exit(401, cjson.encode({ error = "invalid_basic_auth" }))
+end
+
+return plugin

--- a/plugins/cors.lua
+++ b/plugins/cors.lua
@@ -1,0 +1,74 @@
+local plugin = {
+  VERSION = "0.1.0",
+  PRIORITY = 100,
+  SCHEMA = {
+    type = "object",
+    additionalProperties = false,
+    properties = {
+      origins = {
+        type = "array",
+        minItems = 1,
+        items = { type = "string" },
+      },
+      methods = {
+        type = "array",
+        minItems = 1,
+        items = { type = "string" },
+      },
+      headers = {
+        type = "array",
+        items = { type = "string" },
+      },
+      max_age = { type = "integer", minimum = 0 },
+      credentials = { type = "boolean" },
+    },
+    required = { "origins", "methods" },
+  },
+}
+
+local function join(values)
+  return table.concat(values, ", ")
+end
+
+local function origin_allowed(origin, origins)
+  for _, allowed in ipairs(origins) do
+    if allowed == "*" or allowed == origin then
+      return true
+    end
+  end
+  return false
+end
+
+function plugin:access(_ctx)
+  local config = gateway.plugin.get_config()
+  local origin = gateway.request.get_header("origin")
+  if not origin or not origin_allowed(origin, config.origins) then
+    return
+  end
+
+  local allow_origin = origin
+  if #config.origins == 1 and config.origins[1] == "*" then
+    allow_origin = "*"
+  end
+
+  gateway.response.set_header("access-control-allow-origin", allow_origin)
+  gateway.response.set_header("vary", "Origin")
+  if config.credentials then
+    gateway.response.set_header("access-control-allow-credentials", "true")
+  end
+
+  if gateway.request.get_method() ~= "OPTIONS" then
+    return
+  end
+
+  gateway.response.set_header("access-control-allow-methods", join(config.methods))
+  if config.headers and #config.headers > 0 then
+    gateway.response.set_header("access-control-allow-headers", join(config.headers))
+  end
+  if config.max_age then
+    gateway.response.set_header("access-control-max-age", tostring(config.max_age))
+  end
+  gateway.response.exit(204, "")
+end
+
+return plugin

--- a/plugins/ip-restriction.lua
+++ b/plugins/ip-restriction.lua
@@ -1,0 +1,86 @@
+local cjson = require("cjson")
+
+local plugin = {
+  VERSION = "0.1.0",
+  PRIORITY = 450,
+  SCHEMA = {
+    type = "object",
+    additionalProperties = false,
+    properties = {
+      allow = {
+        type = "array",
+        items = { type = "string" },
+      },
+      deny = {
+        type = "array",
+        items = { type = "string" },
+      },
+      status_code = { type = "integer", minimum = 400, maximum = 599 },
+      message = { type = "string" },
+    },
+  },
+}
+
+local function ipv4_to_int(ip)
+  local a, b, c, d = ip:match("^(%d+)%.(%d+)%.(%d+)%.(%d+)$")
+  if not a then
+    return nil
+  end
+
+  a = tonumber(a)
+  b = tonumber(b)
+  c = tonumber(c)
+  d = tonumber(d)
+  for _, value in ipairs({ a, b, c, d }) do
+    if value < 0 or value > 255 then
+      return nil
+    end
+  end
+
+  return ((a * 256 + b) * 256 + c) * 256 + d
+end
+
+local function match_entry(ip, entry)
+  local base, prefix = entry:match("^([^/]+)/(%d+)$")
+  if not prefix then
+    return ip == entry
+  end
+
+  local ip_value = ipv4_to_int(ip)
+  local base_value = ipv4_to_int(base)
+  prefix = tonumber(prefix)
+  if not ip_value or not base_value or prefix < 0 or prefix > 32 then
+    return false
+  end
+
+  local host_bits = 32 - prefix
+  local block_size = 2 ^ host_bits
+  return math.floor(ip_value / block_size) == math.floor(base_value / block_size)
+end
+
+local function list_matches(ip, entries)
+  for _, entry in ipairs(entries or {}) do
+    if match_entry(ip, entry) then
+      return true
+    end
+  end
+  return false
+end
+
+function plugin:access(_ctx)
+  local config = gateway.plugin.get_config()
+  local client_ip = gateway.request.get_client_ip()
+  local denied = list_matches(client_ip, config.deny)
+  local allow_list = config.allow or {}
+  local allowed = (#allow_list == 0) or list_matches(client_ip, allow_list)
+
+  if denied or not allowed then
+    gateway.response.set_header("content-type", "application/json")
+    gateway.response.exit(
+      config.status_code or 403,
+      cjson.encode({ error = config.message or "ip_not_allowed", client_ip = client_ip })
+    )
+  end
+end
+
+return plugin

--- a/plugins/request-size-limiting.lua
+++ b/plugins/request-size-limiting.lua
@@ -1,0 +1,35 @@
+local cjson = require("cjson")
+
+local plugin = {
+  VERSION = "0.1.0",
+  PRIORITY = 350,
+  SCHEMA = {
+    type = "object",
+    additionalProperties = false,
+    properties = {
+      max_bytes = { type = "integer", minimum = 1 },
+      status_code = { type = "integer", minimum = 400, maximum = 599 },
+      message = { type = "string" },
+    },
+    required = { "max_bytes" },
+  },
+}
+
+function plugin:access(_ctx)
+  local config = gateway.plugin.get_config()
+  local content_length = gateway.request.get_header("content-length")
+  if not content_length then
+    return
+  end
+
+  local size = tonumber(content_length)
+  if size and size > config.max_bytes then
+    gateway.response.set_header("content-type", "application/json")
+    gateway.response.exit(
+      config.status_code or 413,
+      cjson.encode({ error = config.message or "payload_too_large", max_bytes = config.max_bytes })
+    )
+  end
+end
+
+return plugin

--- a/plugins/request-transformer.lua
+++ b/plugins/request-transformer.lua
@@ -1,0 +1,62 @@
+local plugin = {
+  VERSION = "0.1.0",
+  PRIORITY = 200,
+  SCHEMA = {
+    type = "object",
+    additionalProperties = false,
+    properties = {
+      add_headers = {
+        type = "object",
+        additionalProperties = { type = "string" },
+      },
+      rename_headers = {
+        type = "object",
+        additionalProperties = { type = "string" },
+      },
+      set_query_params = {
+        type = "object",
+        additionalProperties = { type = "string" },
+      },
+      remove_query_params = {
+        type = "array",
+        items = { type = "string" },
+      },
+      rewrite_path = { type = "string" },
+    },
+  },
+}
+
+local function apply_map(map_value, callback)
+  if not map_value then
+    return
+  end
+  for key, value in pairs(map_value) do
+    callback(key, value)
+  end
+end
+
+function plugin:access(_ctx)
+  local config = gateway.plugin.get_config()
+  if config.rewrite_path then
+    gateway.service.request.set_path(config.rewrite_path)
+  end
+  apply_map(config.add_headers, function(name, value)
+    gateway.service.request.set_header(name, value)
+  end)
+  apply_map(config.rename_headers, function(from_name, to_name)
+    local value = gateway.request.get_header(from_name)
+    if value then
+      gateway.service.request.set_header(to_name, value)
+    end
+  end)
+  apply_map(config.set_query_params, function(name, value)
+    gateway.service.request.set_query_param(name, value)
+  end)
+  if config.remove_query_params then
+    for _, name in ipairs(config.remove_query_params) do
+      gateway.service.request.remove_query_param(name)
+    end
+  end
+end
+
+return plugin

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -51,6 +51,16 @@ dump_stack_diagnostics() {
     docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" logs fake-jwks gateway-manager envoy || true
 }
 
+build_stack() {
+    if docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" build --quiet 2>&1; then
+        return 0
+    fi
+
+    log "Default Docker build failed; retrying with the legacy builder"
+    DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 \
+        docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" build 2>&1
+}
+
 pass() {
     PASSED=$((PASSED + 1))
     TOTAL=$((TOTAL + 1))
@@ -151,7 +161,7 @@ start_stack() {
     cd "$SCRIPT_DIR"
 
     if [ "${SKIP_BUILD:-0}" != "1" ]; then
-        docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" build --quiet 2>&1
+        build_stack
     fi
 
     if ! docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" up -d; then


### PR DESCRIPTION
## Summary
- add a bundled first wave of Lua plugins under `plugins/`
- expand the plugin SDK with query access, client IP access, and path/query rewrites
- run plugins before built-in method enforcement so CORS preflight can short-circuit cleanly
- widen the static Envoy ext_authz header allowlists so plugins can inspect request headers and mutate upstream request headers
- add engine, registry, and ext_authz integration tests for the new plugin behavior

## Issue Links
Part of https://github.com/shikarii/OpenApiGateway/issues/62
Advances https://github.com/shikarii/OpenApiGateway/issues/63
Advances https://github.com/shikarii/OpenApiGateway/issues/64
Advances https://github.com/shikarii/OpenApiGateway/issues/65
Advances https://github.com/shikarii/OpenApiGateway/issues/66
Advances https://github.com/shikarii/OpenApiGateway/issues/67
Advances https://github.com/shikarii/OpenApiGateway/issues/68

## Tests
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `bash -lc "tr -d '\r' < tools/check-loc.sh | bash"`
- local e2e run via a CRLF-normalized `tests/e2e/run.sh`

## Tradeoffs / Residual Risk
- This is a strong first pass on Epic 4, not the full closeout of the epic.
- The bundled plugins are request-phase focused and fit the current ext_authz architecture well.
- Header-sourced credential stripping is still limited by the current ext_authz mutation path, so `hide_credentials` is only enforced for query-sourced API keys in this pass.
- The static Envoy config path now allows plugin header inspection/mutation, but the xDS ext_authz proto in this repo is still intentionally minimal and will need a follow-up pass if we want the same header allowlist richness there.
